### PR TITLE
Pointer on Breadcrumb Items

### DIFF
--- a/src/app/global/components/app-breadcrumbs/app-breadcrumbs.vue
+++ b/src/app/global/components/app-breadcrumbs/app-breadcrumbs.vue
@@ -215,6 +215,10 @@ export default {
   height: 100% !important;
 }
 
+.bx--link {
+  cursor: pointer !important;
+}
+
 .bx--breadcrumb {
   display: flex !important;
 }


### PR DESCRIPTION
### Context

Breadcrumbs currently show the text cursor, instead of the pointer feature they should.

### Actions

- [x] Add `cursor: pointer !important;` to breadcrumb items

cc/ @drewalth 