### PR TITLE
make layout-two-thirds full width on small screens

### DIFF
--- a/src/app/global/layout/layouts/layout-two-thirds.vue
+++ b/src/app/global/layout/layouts/layout-two-thirds.vue
@@ -3,20 +3,20 @@
     <div class="bx--row">
       <template v-if="options.sidebar.left">
         <div
-          class="bx--col-sm-4 bx--col-md-6 bx--col-lg-6 bx--col-max-5"
+          class="bx--col-sm-16 bx--col-md-8 bx--col-lg-6"
         >
           <slot name="sidebar" />
         </div>
-        <div class="bx--col-sm-4 bx--col-md-6 bx--col-lg-10 ">
+        <div class="bx--col-sm-16 bx--col-md-8 bx--col-lg-10 ">
           <slot name="main" />
         </div>
       </template>
       <template v-else>
-        <div class="bx--col-sm-4 bx--col-md-8 bx--col-lg-10">
+        <div class="bx--col-sm-16 bx--col-md-8 bx--col-lg-10">
           <slot name="main" />
         </div>
         <div
-          class="bx--col-sm-4 bx--col-md-6 bx--col-lg-6 bx--col-max-5 bx--offset-max-1"
+          class="bx--col-sm-16 bx--col-md-8 bx--col-lg-6 "
         >
           <slot name="sidebar" />
         </div>


### PR DESCRIPTION
UI tweak to ensure `layout-two-thirds` uses the full width once the components stack.