### PR TITLE
quick styling fix on map detail page

### DIFF
--- a/src/app/views/river-detail/map-tab/map-tab.vue
+++ b/src/app/views/river-detail/map-tab/map-tab.vue
@@ -20,7 +20,7 @@
             class="mb-md"
           />
         </div>
-        <div class="bx--col-sm-12 bx--col-md-4 bx--col-lg-4 bx--col-max-4">
+        <div class="bx--col-sm-12 bx--col-md-12 bx--col-lg-4 bx--col-max-4">
           <info-panel
             :feature="detailFeature"
           />


### PR DESCRIPTION
quick style change to ensure on `md` breakpoint once the sidebar drops to the bottom it's full-width