### PR TITLE
Bug/map event called continuously

### DIFF
--- a/src/app/views/river-index/components/nwi-fullscreen-toggle.vue
+++ b/src/app/views/river-index/components/nwi-fullscreen-toggle.vue
@@ -19,7 +19,7 @@ export default {
   props: {
     fullscreenTarget: {
       type: String,
-      required: true
+      required: false
     }
   },
   data: () => ({

--- a/src/app/views/river-index/components/nwi-map.vue
+++ b/src/app/views/river-index/components/nwi-map.vue
@@ -506,12 +506,9 @@ export default {
       this.map.on('styledata', this.loadAWMapData)
       this.map.on('styledata', this.modifyMapboxBaseStyle)
 
-      // unfortunately this has to hook onto 'data' because we can't queue it directly after search
-      // results are called because of the poorly designed and async nature of map filtering and
-      // queryRenderedFeatures...which means it gets called a lot more than it needs to, hence the
-      // debouncing and slightly clunky UX
+      // TODO: if/when search starts working, we may need to figure out
+      // how to trigger `debouncedUpdateReachesInViewport` on search complete
       this.map.on('moveend', this.debouncedUpdateReachesInViewport)
-      this.map.on('data', this.debouncedUpdateReachesInViewport)
 
       // ensures that when map is rendered in a tab, it sizes properly when the tab is opened
       topic.subscribe('tab-changed', () => {


### PR DESCRIPTION
The map was triggering this event continuously which, among other things, kept causing my vue dev tools to explode.

This event handler was supposed to handle updating the table when search results were applied to the map. But there's got to be a better way to do that, and our search endpoint basically isn't working right now anyway, so I just pulled it out. When we get search working (PHP side...), we can worry about it.