### PR TITLE
fix rapid editing when rloc not present

### DIFF
--- a/src/app/views/river-detail/main-tab/components/rapids-section/components/rapid-edit-modal.vue
+++ b/src/app/views/river-detail/main-tab/components/rapids-section/components/rapid-edit-modal.vue
@@ -231,16 +231,21 @@ export default {
   },
   mounted () {
     this.renderEditor = true
+    let distance
     if (this.activeRapid) {
       this.formData = Object.assign(this.formData, this.activeRapid)
-      // parse rloc into coords
-      this.formData.geom = this.getGeomFromWKB(this.activeRapid.rloc)
-      this.initialRapidDescription = this.activeRapid.description
-    } else {
-      // generate a point on the reach geom to be moved around
-      if (this.reachGeom) {
-        this.formData.geom = along(this.reachGeom, 0, {}).geometry
+      if (this.activeRapid.rloc) {
+        // parse rloc into coords
+        this.formData.geom = this.getGeomFromWKB(this.activeRapid.rloc)
       }
+      distance = this.activeRapid.distance
+      this.initialRapidDescription = this.activeRapid.description
+    }
+    if (!this.formData.geom.coordinates) {
+      // if distance is present, use it to calculate the point
+      // otherwise, create a point anywhere on the line
+      const distanceAlong = distance || 0
+      this.formData.geom = along(this.reachGeom, distanceAlong, { units: 'miles' }).geometry
     }
   }
 }

--- a/src/app/views/river-detail/main-tab/components/rapids-section/components/rapid-edit-modal.vue
+++ b/src/app/views/river-detail/main-tab/components/rapids-section/components/rapid-edit-modal.vue
@@ -241,7 +241,7 @@ export default {
       distance = this.activeRapid.distance
       this.initialRapidDescription = this.activeRapid.description
     }
-    if (!this.formData.geom.coordinates) {
+    if (!this.formData.geom.coordinates.length && this.reachGeom) {
       // if distance is present, use it to calculate the point
       // otherwise, create a point anywhere on the line
       const distanceAlong = distance || 0


### PR DESCRIPTION
@drewalth this resolves #71 *and* does something cool and new that I hadn't thought of -- if a rapid doesn't have an `rloc` (many seem not to) but it does have `distance`, I actually use the `distance` field to locate the rapid on the map! huzzah.