### PR TITLE
hide map banner on map tab and fix small router bug

### DIFF
--- a/src/app/views/river-detail/river-detail.vue
+++ b/src/app/views/river-detail/river-detail.vue
@@ -235,14 +235,6 @@ export default {
       return 'Notification20'
     }
   },
-  watch: {
-    activeTabIndex (v) {
-      const path = `/river-detail/${this.$route.params.id}/${this.$options.tabs[Number(v)].path}`
-      if (this.$route.path !== path) {
-        this.$router.replace(path)
-      }
-    }
-  },
   methods: {
     toggleEditMode () {
       if (this.user) {
@@ -308,6 +300,14 @@ export default {
 
       next()
     })
+
+    // set activeTabIndex to match route that the page initialized on
+    if (this.$route.name) {
+      const tabName = this.$route.name.replace('-tab', '')
+      const tabIndex = this.$options.tabs.findIndex(ele => (ele.path === tabName))
+
+      this.activeTabIndex = tabIndex.toString()
+    }
   }
 }
 </script>

--- a/src/app/views/river-detail/river-detail.vue
+++ b/src/app/views/river-detail/river-detail.vue
@@ -61,14 +61,19 @@
               theme="dark"
               hide-text
             />
-            <page-banner
-              v-if="!loading && data"
-              :title="data.river"
-              :subtitle="data.section"
-              :geom="data.geom"
-              :reach-id="$route.params.id"
-              map
-            />
+            <transition
+              :name="transitionName"
+              mode="out-in"
+            >
+              <page-banner
+                v-if="activeTabIndex !== '2' && !loading && data"
+                :title="data.river"
+                :subtitle="data.section"
+                :geom="data.geom"
+                :reach-id="$route.params.id"
+                map
+              />
+            </transition>
           </div>
         </div>
       </div>
@@ -232,7 +237,10 @@ export default {
   },
   watch: {
     activeTabIndex (v) {
-      this.$router.replace(`/river-detail/${this.$route.params.id}/${this.$options.tabs[Number(v)].path}`)
+      const path = `/river-detail/${this.$route.params.id}/${this.$options.tabs[Number(v)].path}`
+      if (this.$route.path !== path) {
+        this.$router.replace(path)
+      }
     }
   },
   methods: {
@@ -249,7 +257,10 @@ export default {
     switchTab (index) {
       if (index !== this.activeTabIndex) {
         this.activeTabIndex = index.toString()
-        this.$router.replace(`/river-detail/${this.$route.params.id}/${this.$options.tabs[index].path}`)
+        const path = `/river-detail/${this.$route.params.id}/${this.$options.tabs[index].path}`
+        if (this.$route.path !== path) {
+          this.$router.replace(`/river-detail/${this.$route.params.id}/${this.$options.tabs[index].path}`)
+        }
       }
     },
     toggleBookmark () {


### PR DESCRIPTION
Hey @drewalth this does two things (should probably have split the commits, sorry):

- transitions map banner to hidden on map tab
- fixes console error about duplicate navigation happening
- fixes issue where the tab menu (on the left) did not initialize with the correct tab dictated by the route on page load