### PR TITLE
Added in public path to webpack config so urls are correct in production

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -5,6 +5,8 @@
  */
 
 module.exports = {
+  publicPath: process.env.VUE_APP_BASE_URL,
+
   /**
    * disables lint on save which disrupts workflow.
    * linting reserved for pre-commit git hook.


### PR DESCRIPTION
All this does is add the publicPath property to the vue app's webpack config so that it appends the right url to the compiled assets. 