### PR TITLE
reinstate the characteristics field on rapids form

### DIFF
--- a/src/app/views/river-detail/main-tab/components/rapids-section/components/rapid-edit-modal.vue
+++ b/src/app/views/river-detail/main-tab/components/rapids-section/components/rapid-edit-modal.vue
@@ -63,14 +63,12 @@
           :options="poiClasses"
           :disabled="formPending"
         />
-        <!-- temporarily commented out bc the carbon component is broken
-             and it keeps throwing errors !-->
-        <!-- <cv-multi-select
+        <cv-multi-select
           v-model="formData.character"
           theme="light"
           :options="poiCharacteristics"
           title="Characteristics"
-        /> -->
+        />
         <ContentEditor
           v-if="renderEditor"
           :content="formData.description"

--- a/src/app/views/river-detail/shared/services/rapids.js
+++ b/src/app/views/river-detail/shared/services/rapids.js
@@ -66,7 +66,7 @@ const createRapid = data => {
         description: data.description,
         difficulty: data.difficulty,
         distance: data.distance,
-        character: [],
+        character: data.character || [],
         approximate: false // change this if approximate is added to form
       }
     }
@@ -98,7 +98,7 @@ const updateRapid = data => {
         description: data.description,
         difficulty: data.difficulty,
         distance: data.distance,
-        character: []
+        character: data.character
       }
     }
   }).then(response => {


### PR DESCRIPTION
reinstates the "characteristics" multi-select and adds it to rapids graphql calls

fully resolves #92 