### PR TITLE
use refs to initialize all mapbox maps instead of ids

### DIFF
--- a/src/app/views/river-detail/main-tab/components/rapids-section/components/nwi-map-editor.vue
+++ b/src/app/views/river-detail/main-tab/components/rapids-section/components/nwi-map-editor.vue
@@ -3,7 +3,10 @@
     id="nwi-map-editor-container"
     :style="height ? `height:${height}px`:''"
   >
-    <div id="nwi-map-editor" />
+    <div
+      id="nwi-map-editor"
+      ref="nwiMapEditor"
+    />
     <nwi-basemap-toggle
       :offset-right="false"
     />
@@ -121,7 +124,7 @@ export default {
     mountMap () {
       mapboxgl.accessToken = mapboxAccessToken
       const mapProps = {
-        container: 'nwi-map-editor',
+        container: this.$refs.nwiMapEditor,
         style: this.baseMapUrl,
         bounds: this.startingBounds,
         fitBoundsOptions: { padding: 80 }

--- a/src/app/views/river-detail/shared/components/geometry-edit-modal/components/geometry-editor.vue
+++ b/src/app/views/river-detail/shared/components/geometry-edit-modal/components/geometry-editor.vue
@@ -50,7 +50,10 @@
           </cv-dropdown-item>
         </cv-dropdown>
       </div>
-      <div id="nhd-editor" />
+      <div
+        id="nhd-editor"
+        ref="nhdEditor"
+      />
       <nwi-basemap-toggle
         :offset-right="false"
       />
@@ -303,7 +306,7 @@ export default {
     mountMap () {
       mapboxgl.accessToken = mapboxAccessToken
       const mapProps = {
-        container: 'nhd-editor',
+        container: this.$refs.nhdEditor,
         style: this.baseMapUrl,
         bounds: this.startingBounds,
         fitBoundsOptions: { padding: 80 },

--- a/src/app/views/river-index/components/nwi-map.vue
+++ b/src/app/views/river-index/components/nwi-map.vue
@@ -5,7 +5,7 @@
   >
     <template v-if="mapboxAccessToken">
       <div
-        :id="mapContainerId"
+        ref="mapContainer"
         class="nwi-map"
       />
       <nwi-map-legend
@@ -139,11 +139,6 @@ export default {
     mapControls: {
       type: Array,
       required: false
-    },
-    mapContainerId: {
-      type: String,
-      required: false,
-      default: 'nwi-map'
     }
   },
   data () {
@@ -505,7 +500,7 @@ export default {
     mountMap () {
       mapboxgl.accessToken = this.mapboxAccessToken
       const mapProps = {
-        container: this.mapContainerId,
+        container: this.$refs.mapContainer,
         style: this.baseMapUrl,
         trackUserLocation: true
       }


### PR DESCRIPTION
this uses refs to initialize all mapbox maps so that they work in the shadow DOM. It's something @drewalth did in the laravel deploy branch for one of the maps, but not all of them, so I applied that across the board for the development branch here. Can be cherry-picked into laravel-deploy until I get that branch fully compatible and able to be merged to development