### PR TITLE
ensure that the map table data is updated whenever sourcedata loads

### DIFF
--- a/src/app/views/river-index/components/nwi-map.vue
+++ b/src/app/views/river-index/components/nwi-map.vue
@@ -465,6 +465,7 @@ export default {
         if (e.isSourceLoaded) {
           this.mapDataLoading = false
         }
+        this.debouncedUpdateReachesInViewport()
       })
       this.map.on('sourcedataloading', () => { this.mapDataLoading = true })
 


### PR DESCRIPTION
resolves the usability issue from https://github.com/AmericanWhitewater/wh2o/issues/1837 where the table didn't always update unless you re-moved the map 