### PR TITLE
add resize on load finish for NWI map to fix intermittent CSS-related…

### DIFF
--- a/src/app/views/river-index/components/nwi-map.vue
+++ b/src/app/views/river-index/components/nwi-map.vue
@@ -461,6 +461,11 @@ export default {
       this.map.on('styledata', this.loadAWMapData)
       this.map.on('styledata', this.modifyMapboxBaseStyle)
 
+      // this is a kind of weird solution to the fact that once in a blue moon,
+      // our app CSS doesn't finish loading before the map is mounted, which causes
+      // the map to render improperly until the window is resized
+      this.map.on('load', this.map.resize)
+
       this.map.on('sourcedata', (e) => {
         if (e.isSourceLoaded) {
           this.mapDataLoading = false


### PR DESCRIPTION
I *think* this resolves the intermittent map-is-part-grey issue that @rosenzw cited here: https://github.com/AmericanWhitewater/wh2o/issues/1837