### PR TITLE
dont hide other reaches on reach detail map tab

### DIFF
--- a/src/app/views/river-index/components/nwi-map.vue
+++ b/src/app/views/river-index/components/nwi-map.vue
@@ -362,10 +362,6 @@ export default {
               ['get', 'reach_id'],
               this.detailReachId
             ])
-          } else if (['projects', 'projectIcons'].includes(mapLayer)) {
-            // projects aren't relevant here, can keep displaying, everything else is reach-specific
-          } else {
-            this.map.setFilter(mapLayer, ['==', ['get', 'id'], this.detailReachId])
           }
         })
       }


### PR DESCRIPTION
un-hides other reaches from detail page map tab so that you can browse around the map on the detail page.

resolves https://github.com/AmericanWhitewater/wh2o/issues/1874