### PR TITLE
lock carbon/vue to 2.27.0 to un-break dropdowns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
     },
     "@apollographql/apollo-tools": {
       "version": "0.4.8",
-      "resolved": "https://npm.americanwhitewater.org:443/@apollographql%2fapollo-tools/-/apollo-tools-0.4.8.tgz",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.8.tgz",
       "integrity": "sha512-W2+HB8Y7ifowcf3YyPHgDI05izyRtOeZ4MqIr7LbTArtmJ0ZHULWpn84SGMW7NAvTV1tFExpHlveHhnXuJfuGA==",
       "dev": true,
       "requires": {
@@ -76,7 +76,7 @@
     },
     "@apollographql/graphql-language-service-interface": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@apollographql%2fgraphql-language-service-interface/-/graphql-language-service-interface-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-language-service-interface/-/graphql-language-service-interface-2.0.2.tgz",
       "integrity": "sha512-28wePK0hlIVjgmvMXMAUq8qRSjz9O+6lqFp4PzOTHtfJfSsjVe9EfjF98zTpHsTgT3HcOxmbqDZZy8jlXtOqEA==",
       "dev": true,
       "requires": {
@@ -87,7 +87,7 @@
     },
     "@apollographql/graphql-language-service-parser": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@apollographql%2fgraphql-language-service-parser/-/graphql-language-service-parser-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-language-service-parser/-/graphql-language-service-parser-2.0.2.tgz",
       "integrity": "sha512-rpTPrEJu1PMaRQxz5P8BZWsixNNhYloS0H0dwTxNBuE3qctbARvR7o8UCKLsmKgTbo+cz3T3a6IAsWlkHgMWGg==",
       "dev": true,
       "requires": {
@@ -96,13 +96,13 @@
     },
     "@apollographql/graphql-language-service-types": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@apollographql%2fgraphql-language-service-types/-/graphql-language-service-types-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-language-service-types/-/graphql-language-service-types-2.0.2.tgz",
       "integrity": "sha512-vE+Dz8pG+Xa1Z2nMl82LoO66lQ6JqBUjaXqLDvS3eMjvA3N4hf+YUDOWfPdNZ0zjhHhHXzUIIZCkax6bXfFbzQ==",
       "dev": true
     },
     "@apollographql/graphql-language-service-utils": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@apollographql%2fgraphql-language-service-utils/-/graphql-language-service-utils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-language-service-utils/-/graphql-language-service-utils-2.0.2.tgz",
       "integrity": "sha512-fDj5rWlTi/czvUS5t7V7I45Ai6bOO3Z7JARYj21Y2xxfbRGtJi6h8FvLX0N/EbzQgo/fiZc/HAhtfwn+OCjD7A==",
       "dev": true,
       "requires": {
@@ -111,7 +111,7 @@
     },
     "@apollographql/graphql-playground-html": {
       "version": "1.6.26",
-      "resolved": "https://npm.americanwhitewater.org:443/@apollographql%2fgraphql-playground-html/-/graphql-playground-html-1.6.26.tgz",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.26.tgz",
       "integrity": "sha512-XAwXOIab51QyhBxnxySdK3nuMEUohhDsHQ5Rbco/V1vjlP75zZ0ZLHD9dTpXTN8uxKxopb2lUvJTq+M4g2Q0HQ==",
       "dev": true,
       "requires": {
@@ -183,13 +183,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://npm.americanwhitewater.org:443/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -208,7 +208,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://npm.americanwhitewater.org:443/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -475,7 +475,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -484,7 +484,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -653,7 +653,7 @@
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "resolved": "https://npm.americanwhitewater.org:443/@babel%2fplugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "dev": true,
       "requires": {
@@ -680,7 +680,7 @@
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@babel%2fplugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
       "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
       "dev": true,
       "requires": {
@@ -698,7 +698,7 @@
     },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@babel%2fplugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dev": true,
       "requires": {
@@ -725,7 +725,7 @@
     },
     "@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@babel%2fplugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
       "requires": {
@@ -743,7 +743,7 @@
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@babel%2fplugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
       "requires": {
@@ -752,7 +752,7 @@
     },
     "@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@babel%2fplugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "dev": true,
       "requires": {
@@ -761,7 +761,7 @@
     },
     "@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@babel%2fplugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "dev": true,
       "requires": {
@@ -1237,7 +1237,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -1329,7 +1329,7 @@
     },
     "@carbon/icon-helpers": {
       "version": "10.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@carbon%2ficon-helpers/-/icon-helpers-10.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.9.0.tgz",
       "integrity": "sha512-JtmCXV7iIc+N5RqQQy+MGT8T+5KcF7+BUKADvHnJKZ8o+ncF5gI4hmrP450dQD76mikI4fqQ0dQflaosesdSPw=="
     },
     "@carbon/icons-vue": {
@@ -1342,7 +1342,7 @@
     },
     "@carbon/import-once": {
       "version": "10.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@carbon%2fimport-once/-/import-once-10.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@carbon/import-once/-/import-once-10.3.0.tgz",
       "integrity": "sha512-PFk3FhMe3psihYtCg3JsyPHismqglnbUqIpz1DCG5Gn/kt0HdVKhGvHdEq7E305rGoBUCKzMn/4xoY9v9mcmlg=="
     },
     "@carbon/layout": {
@@ -1351,14 +1351,14 @@
       "integrity": "sha512-P9ueDQWpq3pF98iHGsCKL4fR/mP8Xhqe3qhBQfA5zgi7/RPy76lKGZR+SUoGX/QCC72vkA/zhJ4+7/I26LhMhQ=="
     },
     "@carbon/vue": {
-      "version": "2.34.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@carbon%2fvue/-/vue-2.34.1.tgz",
-      "integrity": "sha512-W51YNck4C89hDWHoVpB8g50ur+hIScNiR+/lopWxuZ8vLnS+iotSu3AL8J+T9jtm8olhC+u9PeXNY8NUQfX3cQ==",
+      "version": "2.27.0",
+      "resolved": "https://npm.americanwhitewater.org:443/@carbon%2fvue/-/vue-2.27.0.tgz",
+      "integrity": "sha512-hMlDaMHwCVxwHnhYycUi4jKl6EdaLjhQY8hn22hwzgEkwwwB7coCTnVSIGao0QTileMjK5tQj4kk3F7pFFZyhw==",
       "requires": {
         "@carbon/icons-vue": "10.10.2",
-        "carbon-components": "10.16.0",
+        "carbon-components": "10.11.2",
         "flatpickr": "4.6.3",
-        "vue": "^2.6.12"
+        "vue": "^2.6.11"
       },
       "dependencies": {
         "@carbon/icons-vue": {
@@ -1370,9 +1370,9 @@
           }
         },
         "carbon-components": {
-          "version": "10.16.0",
-          "resolved": "https://npm.americanwhitewater.org:443/carbon-components/-/carbon-components-10.16.0.tgz",
-          "integrity": "sha512-7MltjxNKEjjJ+TOJv3qexE2wBiXQ5qNtMb+in2OJqAWEfixeDHLB+ZtkShAQmKzNw5jIX7w8jfsp2JC4CkApiw==",
+          "version": "10.11.2",
+          "resolved": "https://npm.americanwhitewater.org:443/carbon-components/-/carbon-components-10.11.2.tgz",
+          "integrity": "sha512-bclmy7lXH3/GXXh5Udwcup51i+MUDbDle1kUEilRF9e6phkVhn7I+qN7y/xuRfE4PuXsBC7CtMVNEjtnie6Qow==",
           "requires": {
             "flatpickr": "4.6.1",
             "lodash.debounce": "^4.0.8",
@@ -1390,7 +1390,7 @@
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/@cnakazawa%2fwatch/-/watch-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
       "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
       "dev": true,
       "requires": {
@@ -1400,7 +1400,7 @@
     },
     "@endemolshinegroup/cosmiconfig-typescript-loader": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@endemolshinegroup%2fcosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.2.tgz",
       "integrity": "sha512-ZHkXKq2XFFmAUdmSZrmqUSIrRM4O9gtkdpxMmV+LQl7kScUnbo6pMnXu6+FTDgZ12aW6SDoZoOJfS56WD+Eu6A==",
       "dev": true,
       "requires": {
@@ -1417,25 +1417,25 @@
     },
     "@hapi/address": {
       "version": "2.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/@hapi%2faddress/-/address-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
       "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
       "dev": true
     },
     "@hapi/bourne": {
       "version": "1.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@hapi%2fbourne/-/bourne-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
       "dev": true
     },
     "@hapi/hoek": {
       "version": "8.5.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@hapi%2fhoek/-/hoek-8.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
       "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
       "dev": true
     },
     "@hapi/joi": {
       "version": "15.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@hapi%2fjoi/-/joi-15.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
       "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
       "dev": true,
       "requires": {
@@ -1447,7 +1447,7 @@
     },
     "@hapi/topo": {
       "version": "3.1.6",
-      "resolved": "https://npm.americanwhitewater.org:443/@hapi%2ftopo/-/topo-3.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
       "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
       "dev": true,
       "requires": {
@@ -1456,7 +1456,7 @@
     },
     "@intervolga/optimize-cssnano-plugin": {
       "version": "1.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/@intervolga%2foptimize-cssnano-plugin/-/optimize-cssnano-plugin-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/@intervolga/optimize-cssnano-plugin/-/optimize-cssnano-plugin-1.0.6.tgz",
       "integrity": "sha512-zN69TnSr0viRSU6cEDIcuPcP67QcpQ6uHACg58FiN9PDrU6SLyGW3MR4tiISbYxy1kDWAVPwD+XwQTWE5cigAA==",
       "dev": true,
       "requires": {
@@ -1526,7 +1526,7 @@
     },
     "@jest/console": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@jest%2fconsole/-/console-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
       "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
       "dev": true,
       "requires": {
@@ -1537,7 +1537,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -1546,7 +1546,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -1565,7 +1565,7 @@
     },
     "@jest/core": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@jest%2fcore/-/core-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
       "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
       "dev": true,
       "requires": {
@@ -1601,19 +1601,19 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
           "dev": true
         },
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -1622,7 +1622,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -1639,7 +1639,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -1650,7 +1650,7 @@
     },
     "@jest/environment": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@jest%2fenvironment/-/environment-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
       "integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
       "dev": true,
       "requires": {
@@ -1662,7 +1662,7 @@
     },
     "@jest/fake-timers": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@jest%2ffake-timers/-/fake-timers-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
       "integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
       "dev": true,
       "requires": {
@@ -1673,7 +1673,7 @@
     },
     "@jest/reporters": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@jest%2freporters/-/reporters-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
       "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
       "dev": true,
       "requires": {
@@ -1702,7 +1702,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -1711,7 +1711,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -1730,7 +1730,7 @@
     },
     "@jest/source-map": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@jest%2fsource-map/-/source-map-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
       "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
       "dev": true,
       "requires": {
@@ -1741,7 +1741,7 @@
     },
     "@jest/test-result": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@jest%2ftest-result/-/test-result-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
       "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
       "dev": true,
       "requires": {
@@ -1752,7 +1752,7 @@
     },
     "@jest/test-sequencer": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@jest%2ftest-sequencer/-/test-sequencer-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
       "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
       "dev": true,
       "requires": {
@@ -1764,7 +1764,7 @@
     },
     "@jest/transform": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@jest%2ftransform/-/transform-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
       "integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
       "dev": true,
       "requires": {
@@ -1788,7 +1788,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -1797,7 +1797,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -1816,7 +1816,7 @@
     },
     "@jest/types": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@jest%2ftypes/-/types-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
       "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
       "dev": true,
       "requires": {
@@ -1827,12 +1827,12 @@
     },
     "@mapbox/extent": {
       "version": "0.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fextent/-/extent-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/extent/-/extent-0.4.0.tgz",
       "integrity": "sha1-PlkfMuHww5gchkI597CsBuYQ+Kk="
     },
     "@mapbox/geojson-area": {
       "version": "0.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fgeojson-area/-/geojson-area-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
       "integrity": "sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=",
       "requires": {
         "wgs84": "0.0.0"
@@ -1840,7 +1840,7 @@
     },
     "@mapbox/geojson-coords": {
       "version": "0.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fgeojson-coords/-/geojson-coords-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-coords/-/geojson-coords-0.0.0.tgz",
       "integrity": "sha1-SEeluWBZZm5SeiE551412E/Vj1A=",
       "requires": {
         "@mapbox/geojson-normalize": "0.0.1",
@@ -1849,7 +1849,7 @@
     },
     "@mapbox/geojson-extent": {
       "version": "0.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fgeojson-extent/-/geojson-extent-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-extent/-/geojson-extent-0.3.2.tgz",
       "integrity": "sha1-ob2yAVr9DgMcGMPyn36yKeThlQ8=",
       "requires": {
         "@mapbox/extent": "0.4.0",
@@ -1860,12 +1860,12 @@
     },
     "@mapbox/geojson-normalize": {
       "version": "0.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fgeojson-normalize/-/geojson-normalize-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-normalize/-/geojson-normalize-0.0.1.tgz",
       "integrity": "sha1-HaHms6et060pkJsw9Dj2BYG3zYA="
     },
     "@mapbox/geojson-rewind": {
       "version": "0.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fgeojson-rewind/-/geojson-rewind-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.0.tgz",
       "integrity": "sha512-73l/qJQgj/T/zO1JXVfuVvvKDgikD/7D/rHAD28S9BG1OTstgmftrmqfCx4U+zQAmtsB6HcDA3a7ymdnJZAQgg==",
       "requires": {
         "concat-stream": "~2.0.0",
@@ -1874,7 +1874,7 @@
       "dependencies": {
         "concat-stream": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/concat-stream/-/concat-stream-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
           "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
           "requires": {
             "buffer-from": "^1.0.0",
@@ -1885,12 +1885,12 @@
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": "https://npm.americanwhitewater.org:443/minimist/-/minimist-1.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://npm.americanwhitewater.org:443/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
@@ -1902,7 +1902,7 @@
     },
     "@mapbox/geojson-types": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fgeojson-types/-/geojson-types-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
       "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
     },
     "@mapbox/geojsonhint": {
@@ -1919,7 +1919,7 @@
     },
     "@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fjsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
     },
     "@mapbox/mapbox-gl-draw": {
@@ -1940,32 +1940,32 @@
     },
     "@mapbox/mapbox-gl-draw-static-mode": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fmapbox-gl-draw-static-mode/-/mapbox-gl-draw-static-mode-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw-static-mode/-/mapbox-gl-draw-static-mode-1.0.1.tgz",
       "integrity": "sha1-2ocwmbYKyvkXkLlhzoSyx2KBUEE="
     },
     "@mapbox/mapbox-gl-supported": {
       "version": "1.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fmapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
       "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg=="
     },
     "@mapbox/point-geometry": {
       "version": "0.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fpoint-geometry/-/point-geometry-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
       "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
     },
     "@mapbox/tiny-sdf": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2ftiny-sdf/-/tiny-sdf-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.1.tgz",
       "integrity": "sha512-Ihn1nZcGIswJ5XGbgFAvVumOgWpvIjBX9jiRlIl46uQG9vJOF51ViBYHF95rEZupuyQbEmhLaDPLQlU7fUTsBg=="
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2funitbezier/-/unitbezier-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
       "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
     },
     "@mapbox/vector-tile": {
       "version": "1.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fvector-tile/-/vector-tile-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
       "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
       "requires": {
         "@mapbox/point-geometry": "~0.1.0"
@@ -1973,12 +1973,12 @@
     },
     "@mapbox/whoots-js": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@mapbox%2fwhoots-js/-/whoots-js-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@mrmlnc%2freaddir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
@@ -1988,7 +1988,7 @@
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@nodelib%2ffs.scandir/-/fs.scandir-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
       "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
       "dev": true,
       "requires": {
@@ -1998,7 +1998,7 @@
       "dependencies": {
         "@nodelib/fs.stat": {
           "version": "2.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/@nodelib%2ffs.stat/-/fs.stat-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
           "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
           "dev": true
         }
@@ -2006,13 +2006,13 @@
     },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@nodelib%2ffs.stat/-/fs.stat-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
     "@nodelib/fs.walk": {
       "version": "1.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/@nodelib%2ffs.walk/-/fs.walk-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
       "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
       "dev": true,
       "requires": {
@@ -2022,7 +2022,7 @@
     },
     "@oclif/color": {
       "version": "0.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@oclif%2fcolor/-/color-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@oclif/color/-/color-0.1.2.tgz",
       "integrity": "sha512-M9o+DOrb8l603qvgz1FogJBUGLqcMFL1aFg2ZEL0FbXJofiNTLOWIeB4faeZTLwE6dt0xH9GpCVpzksMMzGbmA==",
       "dev": true,
       "requires": {
@@ -2035,13 +2035,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -2050,7 +2050,7 @@
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
@@ -2069,7 +2069,7 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "dev": true,
               "requires": {
@@ -2089,13 +2089,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -2143,7 +2143,7 @@
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -2152,7 +2152,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -2184,7 +2184,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
@@ -2216,7 +2216,7 @@
         },
         "wrap-ansi": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
           "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
           "dev": true,
           "requires": {
@@ -2227,7 +2227,7 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
@@ -2239,7 +2239,7 @@
             },
             "string-width": {
               "version": "2.1.1",
-              "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
@@ -2249,7 +2249,7 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
@@ -2383,7 +2383,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
@@ -2539,13 +2539,13 @@
     },
     "@oclif/linewrap": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@oclif%2flinewrap/-/linewrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
       "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
       "dev": true
     },
     "@oclif/parser": {
       "version": "3.8.5",
-      "resolved": "https://npm.americanwhitewater.org:443/@oclif%2fparser/-/parser-3.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.5.tgz",
       "integrity": "sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==",
       "dev": true,
       "requires": {
@@ -2557,7 +2557,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -2566,7 +2566,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -2585,7 +2585,7 @@
     },
     "@oclif/plugin-autocomplete": {
       "version": "0.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@oclif%2fplugin-autocomplete/-/plugin-autocomplete-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-0.2.0.tgz",
       "integrity": "sha512-pHbaE2PH7d9lHjCgFrrQ+ZIwvY+7OAQaGoaANqDbicBNDK/Rszt4N4oGj22dJT7sCQ8a/3Eh942rjxYIq9Mi9Q==",
       "dev": true,
       "requires": {
@@ -2600,7 +2600,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -2609,7 +2609,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -2635,7 +2635,7 @@
         },
         "fs-extra": {
           "version": "7.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/fs-extra/-/fs-extra-7.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
           "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "dev": true,
           "requires": {
@@ -2646,7 +2646,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -2654,7 +2654,7 @@
     },
     "@oclif/plugin-help": {
       "version": "2.2.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@oclif%2fplugin-help/-/plugin-help-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.2.3.tgz",
       "integrity": "sha512-bGHUdo5e7DjPJ0vTeRBMIrfqTRDBfyR5w0MP41u0n3r7YG5p14lvMmiCXxi6WDaP2Hw5nqx3PnkAIntCKZZN7g==",
       "dev": true,
       "requires": {
@@ -2670,13 +2670,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -2685,7 +2685,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -2696,7 +2696,7 @@
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
@@ -2708,7 +2708,7 @@
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
@@ -2719,7 +2719,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -2764,7 +2764,7 @@
         },
         "wrap-ansi": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
           "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
           "dev": true,
           "requires": {
@@ -2775,13 +2775,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "string-width": {
               "version": "2.1.1",
-              "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
@@ -2791,7 +2791,7 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
@@ -2804,7 +2804,7 @@
     },
     "@oclif/plugin-not-found": {
       "version": "1.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/@oclif%2fplugin-not-found/-/plugin-not-found-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-1.2.4.tgz",
       "integrity": "sha512-G440PCuMi/OT8b71aWkR+kCWikngGtyRjOR24sPMDbpUFV4+B3r51fz1fcqeUiiEOYqUpr0Uy/sneUe1O/NfBg==",
       "dev": true,
       "requires": {
@@ -2817,19 +2817,19 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
           "dev": true
         },
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -2838,7 +2838,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -2849,7 +2849,7 @@
         },
         "cli-ux": {
           "version": "4.9.3",
-          "resolved": "https://npm.americanwhitewater.org:443/cli-ux/-/cli-ux-4.9.3.tgz",
+          "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-4.9.3.tgz",
           "integrity": "sha512-/1owvF0SZ5Gn54cgrikJ0QskgTzeg30HGjkmjFoaHDJzAqFpuX1DBpFR8aLvsE1J5s9MgeYRENQK4BFwOag5VA==",
           "dev": true,
           "requires": {
@@ -2890,7 +2890,7 @@
         },
         "fs-extra": {
           "version": "7.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/fs-extra/-/fs-extra-7.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
           "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "dev": true,
           "requires": {
@@ -2907,13 +2907,13 @@
         },
         "indent-string": {
           "version": "3.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/indent-string/-/indent-string-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
           "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -2955,7 +2955,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -2964,7 +2964,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -3020,7 +3020,7 @@
         },
         "load-json-file": {
           "version": "5.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/load-json-file/-/load-json-file-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
           "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
           "dev": true,
           "requires": {
@@ -3033,7 +3033,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
@@ -3048,7 +3048,7 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -3058,7 +3058,7 @@
         },
         "path-key": {
           "version": "3.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/path-key/-/path-key-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
@@ -3082,7 +3082,7 @@
         },
         "type-fest": {
           "version": "0.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/type-fest/-/type-fest-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
           "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
           "dev": true
         },
@@ -3096,7 +3096,7 @@
     },
     "@oclif/plugin-warn-if-update-available": {
       "version": "1.7.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@oclif%2fplugin-warn-if-update-available/-/plugin-warn-if-update-available-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-1.7.0.tgz",
       "integrity": "sha512-Nwyz3BJ8RhsfQ+OmFSsJSPIfn5YJqMrCzPh72Zgo2jqIjKIBWD8N9vTTe4kZlpeUUn77SyXFfwlBQbNCL5OEuQ==",
       "dev": true,
       "requires": {
@@ -3113,7 +3113,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -3122,7 +3122,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -3148,7 +3148,7 @@
         },
         "fs-extra": {
           "version": "7.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/fs-extra/-/fs-extra-7.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
           "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "dev": true,
           "requires": {
@@ -3159,7 +3159,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -3167,37 +3167,37 @@
     },
     "@oclif/screen": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/@oclif%2fscreen/-/screen-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
       "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==",
       "dev": true
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@protobufjs%2faspromise/-/aspromise-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
       "dev": true
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@protobufjs%2fbase64/-/base64-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
       "dev": true
     },
     "@protobufjs/codegen": {
       "version": "2.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/@protobufjs%2fcodegen/-/codegen-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
       "dev": true
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@protobufjs%2feventemitter/-/eventemitter-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
       "dev": true
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@protobufjs%2ffetch/-/fetch-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
       "dev": true,
       "requires": {
@@ -3207,31 +3207,31 @@
     },
     "@protobufjs/float": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@protobufjs%2ffloat/-/float-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
       "dev": true
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@protobufjs%2finquire/-/inquire-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
       "dev": true
     },
     "@protobufjs/path": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@protobufjs%2fpath/-/path-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
       "dev": true
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@protobufjs%2fpool/-/pool-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
       "dev": true
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@protobufjs%2futf8/-/utf8-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
       "dev": true
     },
@@ -3321,7 +3321,7 @@
     },
     "@soda/friendly-errors-webpack-plugin": {
       "version": "1.7.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@soda%2ffriendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/@soda/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.1.tgz",
       "integrity": "sha512-cWKrGaFX+rfbMrAxVv56DzhPNqOJPZuNIS2HGMELtgGzb+vsMzyig9mml5gZ/hr2BGtSLV+dP2LUEuAL8aG2mQ==",
       "dev": true,
       "requires": {
@@ -3332,19 +3332,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3363,7 +3363,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -3372,7 +3372,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -3380,7 +3380,7 @@
     },
     "@soda/get-current-script": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@soda%2fget-current-script/-/get-current-script-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@soda/get-current-script/-/get-current-script-1.0.2.tgz",
       "integrity": "sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==",
       "dev": true
     },
@@ -3395,7 +3395,7 @@
     },
     "@stylelint/postcss-markdown": {
       "version": "0.36.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@stylelint%2fpostcss-markdown/-/postcss-markdown-0.36.1.tgz",
+      "resolved": "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.1.tgz",
       "integrity": "sha512-iDxMBWk9nB2BPi1VFQ+Dc5+XpvODBHw2n3tYpaBZuEAFQlbtF9If0Qh5LTTwSi/XwdbJ2jt+0dis3i8omyggpw==",
       "dev": true,
       "requires": {
@@ -3405,7 +3405,7 @@
     },
     "@turf/along": {
       "version": "6.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2falong/-/along-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-6.0.1.tgz",
       "integrity": "sha512-6PptAcrsFR3o0Flpktk8Vo68W2txEVTh14zjoTVu+H5docd2+pv5/upA77bg3YFBoJgAxmUFt1leDdjReJ44BQ==",
       "requires": {
         "@turf/bearing": "6.x",
@@ -3417,7 +3417,7 @@
     },
     "@turf/bbox": {
       "version": "6.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fbbox/-/bbox-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.0.1.tgz",
       "integrity": "sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==",
       "requires": {
         "@turf/helpers": "6.x",
@@ -3426,7 +3426,7 @@
     },
     "@turf/bbox-polygon": {
       "version": "6.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fbbox-polygon/-/bbox-polygon-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-6.0.1.tgz",
       "integrity": "sha512-f6BK6GOzUNjmJeOYHklk/5LNcQMQbo51gvAM10dTM5IqzKP01KM5bgV88uOKfSZB0HRQVpaRV1tgXk2bg5cPRg==",
       "requires": {
         "@turf/helpers": "6.x"
@@ -3434,7 +3434,7 @@
     },
     "@turf/bearing": {
       "version": "6.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fbearing/-/bearing-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.0.1.tgz",
       "integrity": "sha512-mXY1NozqV9EFfBTbUItujwfqfQF0G/Xe2fzvnZle90ekPEUfhi4Dgf5JswJTd96J9LiT8kcd6Jonp5khnx0wIg==",
       "requires": {
         "@turf/helpers": "6.x",
@@ -3443,7 +3443,7 @@
     },
     "@turf/boolean-point-in-polygon": {
       "version": "6.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fboolean-point-in-polygon/-/boolean-point-in-polygon-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.0.1.tgz",
       "integrity": "sha512-FKLOZ124vkJhjzNSDcqpwp2NvfnsbYoUOt5iAE7uskt4svix5hcjIEgX9sELFTJpbLGsD1mUbKdfns8tZxcMNg==",
       "requires": {
         "@turf/helpers": "6.x",
@@ -3452,7 +3452,7 @@
     },
     "@turf/boolean-point-on-line": {
       "version": "6.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fboolean-point-on-line/-/boolean-point-on-line-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-6.0.1.tgz",
       "integrity": "sha512-Vl724Tzh4CF/13kgblOAQnMcHagromCP1EfyJ9G/8SxpSoTYeY2G6FmmcpbW51GqKxC7xgM9+Pck50dun7oYkg==",
       "requires": {
         "@turf/helpers": "6.x",
@@ -3461,7 +3461,7 @@
     },
     "@turf/buffer": {
       "version": "5.1.5",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fbuffer/-/buffer-5.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
       "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
       "requires": {
         "@turf/bbox": "^5.1.5",
@@ -3475,7 +3475,7 @@
       "dependencies": {
         "@turf/bbox": {
           "version": "5.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fbbox/-/bbox-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
           "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
           "requires": {
             "@turf/helpers": "^5.1.5",
@@ -3484,12 +3484,12 @@
         },
         "@turf/helpers": {
           "version": "5.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fhelpers/-/helpers-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
           "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
         },
         "@turf/meta": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fmeta/-/meta-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
           "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
           "requires": {
             "@turf/helpers": "^5.1.5"
@@ -3499,7 +3499,7 @@
     },
     "@turf/center": {
       "version": "5.1.5",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fcenter/-/center-5.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
       "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
       "requires": {
         "@turf/bbox": "^5.1.5",
@@ -3508,7 +3508,7 @@
       "dependencies": {
         "@turf/bbox": {
           "version": "5.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fbbox/-/bbox-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
           "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
           "requires": {
             "@turf/helpers": "^5.1.5",
@@ -3517,12 +3517,12 @@
         },
         "@turf/helpers": {
           "version": "5.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fhelpers/-/helpers-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
           "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
         },
         "@turf/meta": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fmeta/-/meta-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
           "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
           "requires": {
             "@turf/helpers": "^5.1.5"
@@ -3547,7 +3547,7 @@
     },
     "@turf/destination": {
       "version": "6.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fdestination/-/destination-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-6.0.1.tgz",
       "integrity": "sha512-MroK4nRdp7as174miCAugp8Uvorhe6rZ7MJiC9Hb4+hZR7gNFJyVKmkdDDXIoCYs6MJQsx0buI+gsCpKwgww0Q==",
       "requires": {
         "@turf/helpers": "6.x",
@@ -3556,7 +3556,7 @@
     },
     "@turf/distance": {
       "version": "6.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fdistance/-/distance-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.0.1.tgz",
       "integrity": "sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==",
       "requires": {
         "@turf/helpers": "6.x",
@@ -3565,12 +3565,12 @@
     },
     "@turf/helpers": {
       "version": "6.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fhelpers/-/helpers-6.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
       "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
     },
     "@turf/invariant": {
       "version": "6.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2finvariant/-/invariant-6.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
       "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
       "requires": {
         "@turf/helpers": "6.x"
@@ -3578,7 +3578,7 @@
     },
     "@turf/length": {
       "version": "6.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2flength/-/length-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-6.0.2.tgz",
       "integrity": "sha512-nyfXMowVtX2dICEG7u7EGC2SMaauVUWIMc9eWQrEauNA/9aw+7wbiuip4GPBoyeXEUUekF0EOjJn5aB9Zc8CzA==",
       "requires": {
         "@turf/distance": "6.x",
@@ -3588,7 +3588,7 @@
     },
     "@turf/line-intersect": {
       "version": "6.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fline-intersect/-/line-intersect-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.0.2.tgz",
       "integrity": "sha512-pfL/lBu7ukBPdTjvSCmcNUzZ83V4R95htwqs5NqU8zeS4R+5KTwacbrOYKztjpmHBwUmPEIIpSbqkUoD0Fp7kg==",
       "requires": {
         "@turf/helpers": "6.x",
@@ -3600,7 +3600,7 @@
     },
     "@turf/line-segment": {
       "version": "6.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fline-segment/-/line-segment-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.0.2.tgz",
       "integrity": "sha512-8AkzDHoNw3X68y115josal+lvdAi4b2P1K0YNTKGyLRBaUhPXVSuMBpMd53FRF1hYEb9UJgMbugF9ZE7m5L6zg==",
       "requires": {
         "@turf/helpers": "6.x",
@@ -3610,7 +3610,7 @@
     },
     "@turf/line-slice": {
       "version": "5.1.5",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fline-slice/-/line-slice-5.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
       "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
       "requires": {
         "@turf/helpers": "^5.1.5",
@@ -3620,7 +3620,7 @@
       "dependencies": {
         "@turf/bearing": {
           "version": "5.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fbearing/-/bearing-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
           "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
           "requires": {
             "@turf/helpers": "^5.1.5",
@@ -3629,7 +3629,7 @@
         },
         "@turf/destination": {
           "version": "5.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fdestination/-/destination-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
           "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
           "requires": {
             "@turf/helpers": "^5.1.5",
@@ -3638,7 +3638,7 @@
         },
         "@turf/distance": {
           "version": "5.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fdistance/-/distance-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
           "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
           "requires": {
             "@turf/helpers": "^5.1.5",
@@ -3647,12 +3647,12 @@
         },
         "@turf/helpers": {
           "version": "5.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fhelpers/-/helpers-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
           "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
         },
         "@turf/invariant": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2finvariant/-/invariant-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
           "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
           "requires": {
             "@turf/helpers": "^5.1.5"
@@ -3660,7 +3660,7 @@
         },
         "@turf/line-intersect": {
           "version": "5.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fline-intersect/-/line-intersect-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
           "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
           "requires": {
             "@turf/helpers": "^5.1.5",
@@ -3672,7 +3672,7 @@
         },
         "@turf/line-segment": {
           "version": "5.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fline-segment/-/line-segment-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
           "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
           "requires": {
             "@turf/helpers": "^5.1.5",
@@ -3682,7 +3682,7 @@
         },
         "@turf/meta": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fmeta/-/meta-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
           "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
           "requires": {
             "@turf/helpers": "^5.1.5"
@@ -3690,7 +3690,7 @@
         },
         "@turf/nearest-point-on-line": {
           "version": "5.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/@turf%2fnearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
           "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
           "requires": {
             "@turf/bearing": "^5.1.5",
@@ -3704,7 +3704,7 @@
         },
         "geojson-rbush": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
           "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
           "requires": {
             "@turf/helpers": "*",
@@ -3716,7 +3716,7 @@
     },
     "@turf/meta": {
       "version": "6.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fmeta/-/meta-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
       "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
       "requires": {
         "@turf/helpers": "6.x"
@@ -3724,7 +3724,7 @@
     },
     "@turf/nearest-point-on-line": {
       "version": "6.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fnearest-point-on-line/-/nearest-point-on-line-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-6.0.2.tgz",
       "integrity": "sha512-re9tSEwYyG1EMo4ObXXAKYVhkMVANPIIJQ1V/J1lKcNfHVc1pYmd3D5jkTNBh+oriI9VL4PVML3eqYE+Zcg0mg==",
       "requires": {
         "@turf/bearing": "6.x",
@@ -3738,7 +3738,7 @@
     },
     "@turf/point-to-line-distance": {
       "version": "6.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fpoint-to-line-distance/-/point-to-line-distance-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-6.0.0.tgz",
       "integrity": "sha512-2UuZFtn8MRfrqBHSqkrH/jm5q/VedyL7a4YC50Nd5FqXs5TgmAB7ms2igSbCkyaOtRypGhMl9fun3Hg5PIVRMQ==",
       "requires": {
         "@turf/bearing": "6.x",
@@ -3773,7 +3773,7 @@
     },
     "@turf/polygon-to-line": {
       "version": "6.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2fpolygon-to-line/-/polygon-to-line-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-6.0.3.tgz",
       "integrity": "sha512-cJUy7VYLAhgnTBOtYFjNzh5bSlAS/qM8gUHXRGrIxI22RUJk4FXs/X2MEJ4Ki2flCiSeOjRIUEawEslNe7w7RA==",
       "requires": {
         "@turf/helpers": "6.x",
@@ -3807,7 +3807,7 @@
     },
     "@turf/rhumb-bearing": {
       "version": "6.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2frhumb-bearing/-/rhumb-bearing-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.0.1.tgz",
       "integrity": "sha512-MVBra8OVfjM4+/N0B3o6cBIYg9p/uRKzA9uk05RfrzasEbUL1vdD23LkTooVL74Yw4UxL8BQD9hS5Re2COJFDA==",
       "requires": {
         "@turf/helpers": "6.x",
@@ -3816,7 +3816,7 @@
     },
     "@turf/rhumb-distance": {
       "version": "6.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@turf%2frhumb-distance/-/rhumb-distance-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.0.1.tgz",
       "integrity": "sha512-3G45DQtQByzzfHFPcCyJdUZFwsd45zfZ7sAb1ddF7mhEj4G70+T2G3GKjInymqDNrbyh2gbG6wQiZSToC8Uf9g==",
       "requires": {
         "@turf/helpers": "6.x",
@@ -3825,7 +3825,7 @@
     },
     "@types/accepts": {
       "version": "1.3.5",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2faccepts/-/accepts-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "dev": true,
       "requires": {
@@ -3891,7 +3891,7 @@
     },
     "@types/body-parser": {
       "version": "1.19.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fbody-parser/-/body-parser-1.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
       "dev": true,
       "requires": {
@@ -3901,7 +3901,7 @@
     },
     "@types/connect": {
       "version": "3.4.33",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fconnect/-/connect-3.4.33.tgz",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
       "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
       "dev": true,
       "requires": {
@@ -3920,7 +3920,7 @@
     },
     "@types/content-disposition": {
       "version": "0.5.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fcontent-disposition/-/content-disposition-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg==",
       "dev": true
     },
@@ -3975,7 +3975,7 @@
     },
     "@types/fs-capacitor": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2ffs-capacitor/-/fs-capacitor-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz",
       "integrity": "sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==",
       "dev": true,
       "requires": {
@@ -4006,7 +4006,7 @@
     },
     "@types/http-assert": {
       "version": "1.5.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fhttp-assert/-/http-assert-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.1.tgz",
       "integrity": "sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ==",
       "dev": true
     },
@@ -4038,13 +4038,13 @@
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fistanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
       "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
       "dev": true
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fistanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
       "dev": true,
       "requires": {
@@ -4053,7 +4053,7 @@
     },
     "@types/istanbul-reports": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fistanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
       "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
       "dev": true,
       "requires": {
@@ -4063,7 +4063,7 @@
     },
     "@types/jest": {
       "version": "24.9.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fjest/-/jest-24.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
       "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
       "dev": true,
       "requires": {
@@ -4078,12 +4078,12 @@
     },
     "@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fjson5/-/json5-0.0.29.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/keygrip": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fkeygrip/-/keygrip-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
       "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==",
       "dev": true
     },
@@ -4105,7 +4105,7 @@
     },
     "@types/koa-compose": {
       "version": "3.2.5",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fkoa-compose/-/koa-compose-3.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
       "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
       "dev": true,
       "requires": {
@@ -4114,7 +4114,7 @@
     },
     "@types/long": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2flong/-/long-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
       "dev": true
     },
@@ -4126,13 +4126,13 @@
     },
     "@types/minimatch": {
       "version": "3.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fminimatch/-/minimatch-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/minimist": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fminimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
       "dev": true
     },
@@ -4143,7 +4143,7 @@
     },
     "@types/node-fetch": {
       "version": "2.5.7",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fnode-fetch/-/node-fetch-2.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
       "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
       "dev": true,
       "requires": {
@@ -4153,7 +4153,7 @@
       "dependencies": {
         "form-data": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/form-data/-/form-data-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
           "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
           "dev": true,
           "requires": {
@@ -4166,19 +4166,19 @@
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fnormalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fparse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "@types/q": {
       "version": "1.5.4",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fq/-/q-1.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
       "dev": true
     },
@@ -4190,7 +4190,7 @@
     },
     "@types/range-parser": {
       "version": "1.2.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2frange-parser/-/range-parser-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
       "dev": true
     },
@@ -4212,19 +4212,19 @@
     },
     "@types/stack-utils": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fstack-utils/-/stack-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
     "@types/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fstrip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
       "dev": true
     },
     "@types/strip-json-comments": {
       "version": "0.0.30",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fstrip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
     },
@@ -4245,7 +4245,7 @@
     },
     "@types/unist": {
       "version": "2.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2funist/-/unist-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "@types/webpack": {
@@ -4314,7 +4314,7 @@
     },
     "@types/yargs-parser": {
       "version": "15.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@types%2fyargs-parser/-/yargs-parser-15.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
@@ -4675,7 +4675,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -4936,13 +4936,13 @@
         },
         "acorn-walk": {
           "version": "7.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/acorn-walk/-/acorn-walk-7.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
           "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
           "dev": true
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
@@ -4957,7 +4957,7 @@
         },
         "cacache": {
           "version": "13.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/cacache/-/cacache-13.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
           "integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
           "dev": true,
           "requires": {
@@ -4981,9 +4981,20 @@
             "unique-filename": "^1.1.1"
           }
         },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "cliui": {
           "version": "6.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/cliui/-/cliui-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
           "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
           "dev": true,
           "requires": {
@@ -4994,7 +5005,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -5012,7 +5023,7 @@
         },
         "find-cache-dir": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
           "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
           "dev": true,
           "requires": {
@@ -5023,7 +5034,7 @@
         },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/find-up/-/find-up-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
@@ -5033,7 +5044,7 @@
         },
         "fs-extra": {
           "version": "7.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/fs-extra/-/fs-extra-7.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
           "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "dev": true,
           "requires": {
@@ -5044,19 +5055,19 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "jest-worker": {
           "version": "25.5.0",
-          "resolved": "https://npm.americanwhitewater.org:443/jest-worker/-/jest-worker-25.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
           "integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
           "dev": true,
           "requires": {
@@ -5064,9 +5075,31 @@
             "supports-color": "^7.0.0"
           }
         },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://npm.americanwhitewater.org:443/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://npm.americanwhitewater.org:443/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/locate-path/-/locate-path-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
@@ -5075,7 +5108,7 @@
         },
         "make-dir": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/make-dir/-/make-dir-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
           "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
@@ -5084,13 +5117,13 @@
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": "https://npm.americanwhitewater.org:443/minimist/-/minimist-1.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
@@ -5105,7 +5138,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/p-locate/-/p-locate-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
@@ -5120,13 +5153,13 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/path-exists/-/path-exists-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
         "pkg-dir": {
           "version": "4.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
           "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
           "dev": true,
           "requires": {
@@ -5135,13 +5168,13 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         },
         "ssri": {
           "version": "7.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ssri/-/ssri-7.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
           "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
           "dev": true,
           "requires": {
@@ -5151,7 +5184,7 @@
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
@@ -5162,7 +5195,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -5195,9 +5228,21 @@
             "webpack-sources": "^1.4.3"
           }
         },
+        "vue-loader-v16": {
+          "version": "npm:vue-loader@16.0.0-rc.1",
+          "resolved": "https://npm.americanwhitewater.org:443/vue-loader/-/vue-loader-16.0.0-rc.1.tgz",
+          "integrity": "sha512-yR+BS90EOXTNieasf8ce9J3TFCpm2DGqoqdbtiwQ33hon3FyIznLX7sKavAq1VmfBnOeV6It0Htg4aniv8ph1g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "hash-sum": "^2.0.0",
+            "loader-utils": "^2.0.0"
+          }
+        },
         "wrap-ansi": {
           "version": "6.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
           "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "requires": {
@@ -5230,13 +5275,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -5245,7 +5290,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -5286,13 +5331,13 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -5357,13 +5402,13 @@
         },
         "hash-sum": {
           "version": "1.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/hash-sum/-/hash-sum-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/lru-cache/-/lru-cache-4.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
@@ -5384,7 +5429,7 @@
         },
         "prettier": {
           "version": "1.19.1",
-          "resolved": "https://npm.americanwhitewater.org:443/prettier/-/prettier-1.19.1.tgz",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
           "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
           "dev": true,
           "optional": true
@@ -5400,7 +5445,7 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -5423,7 +5468,7 @@
     },
     "@vue/eslint-config-standard": {
       "version": "5.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@vue%2feslint-config-standard/-/eslint-config-standard-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/eslint-config-standard/-/eslint-config-standard-5.1.2.tgz",
       "integrity": "sha512-FTz0k77dIrj9r3xskt9jsZyL/YprrLiPRf4m3k7G6dZ5PKuD6OPqYrHR9eduUmHDFpTlRgFpTVQrq+1el9k3QQ==",
       "dev": true,
       "requires": {
@@ -5460,13 +5505,13 @@
     },
     "@vue/web-component-wrapper": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@vue%2fweb-component-wrapper/-/web-component-wrapper-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/web-component-wrapper/-/web-component-wrapper-1.2.0.tgz",
       "integrity": "sha512-Xn/+vdm9CjuC9p3Ae+lTClNutrVhsXpzxvoTXXtoys6kVRX9FkueSUAqSWAyZntmVLlR4DosBV4pH8y5Z/HbUw==",
       "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fast/-/ast-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
       "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
       "dev": true,
       "requires": {
@@ -5477,25 +5522,25 @@
     },
     "@webassemblyjs/floating-point-hex-parser": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2ffloating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
       "integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fhelper-api-error/-/helper-api-error-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
       "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fhelper-buffer/-/helper-buffer-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
       "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fhelper-code-frame/-/helper-code-frame-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
       "integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
       "dev": true,
       "requires": {
@@ -5504,13 +5549,13 @@
     },
     "@webassemblyjs/helper-fsm": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fhelper-fsm/-/helper-fsm-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
       "integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fhelper-module-context/-/helper-module-context-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
       "integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
       "dev": true,
       "requires": {
@@ -5519,13 +5564,13 @@
     },
     "@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fhelper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
       "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fhelper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
       "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
       "dev": true,
       "requires": {
@@ -5537,7 +5582,7 @@
     },
     "@webassemblyjs/ieee754": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fieee754/-/ieee754-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
       "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
       "dev": true,
       "requires": {
@@ -5546,7 +5591,7 @@
     },
     "@webassemblyjs/leb128": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fleb128/-/leb128-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
       "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
       "dev": true,
       "requires": {
@@ -5555,13 +5600,13 @@
     },
     "@webassemblyjs/utf8": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2futf8/-/utf8-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
       "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fwasm-edit/-/wasm-edit-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
       "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
       "dev": true,
       "requires": {
@@ -5577,7 +5622,7 @@
     },
     "@webassemblyjs/wasm-gen": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fwasm-gen/-/wasm-gen-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
       "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
       "dev": true,
       "requires": {
@@ -5590,7 +5635,7 @@
     },
     "@webassemblyjs/wasm-opt": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fwasm-opt/-/wasm-opt-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
       "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
       "dev": true,
       "requires": {
@@ -5602,7 +5647,7 @@
     },
     "@webassemblyjs/wasm-parser": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fwasm-parser/-/wasm-parser-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
       "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
       "dev": true,
       "requires": {
@@ -5616,7 +5661,7 @@
     },
     "@webassemblyjs/wast-parser": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fwast-parser/-/wast-parser-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
       "integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
       "dev": true,
       "requires": {
@@ -5630,7 +5675,7 @@
     },
     "@webassemblyjs/wast-printer": {
       "version": "1.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@webassemblyjs%2fwast-printer/-/wast-printer-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
       "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
       "dev": true,
       "requires": {
@@ -5657,19 +5702,19 @@
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/@xtuc%2fieee754/-/ieee754-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "dev": true
     },
     "@xtuc/long": {
       "version": "4.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/@xtuc%2flong/-/long-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
     "JSV": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/JSV/-/JSV-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
       "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
     },
     "abab": {
@@ -5680,13 +5725,13 @@
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/abbrev/-/abbrev-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "accepts": {
       "version": "1.3.7",
-      "resolved": "https://npm.americanwhitewater.org:443/accepts/-/accepts-1.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "requires": {
         "mime-types": "~2.1.24",
@@ -5701,7 +5746,7 @@
     },
     "acorn-globals": {
       "version": "4.3.4",
-      "resolved": "https://npm.americanwhitewater.org:443/acorn-globals/-/acorn-globals-4.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
       "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
       "dev": true,
       "requires": {
@@ -5717,13 +5762,13 @@
     },
     "acorn-walk": {
       "version": "6.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/acorn-walk/-/acorn-walk-6.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
     },
     "address": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/address/-/address-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.1.2.tgz",
       "integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==",
       "dev": true
     },
@@ -5751,7 +5796,7 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
       "dev": true
     },
@@ -5763,19 +5808,19 @@
     },
     "alphanum-sort": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/amdefine/-/amdefine-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-align": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/ansi-align/-/ansi-align-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
@@ -5784,13 +5829,13 @@
     },
     "ansi-colors": {
       "version": "3.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
       "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
       "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
       "dev": true,
       "requires": {
@@ -5799,7 +5844,7 @@
       "dependencies": {
         "type-fest": {
           "version": "0.11.0",
-          "resolved": "https://npm.americanwhitewater.org:443/type-fest/-/type-fest-0.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
           "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
           "dev": true
         }
@@ -5807,41 +5852,41 @@
     },
     "ansi-html": {
       "version": "0.0.7",
-      "resolved": "https://npm.americanwhitewater.org:443/ansi-html/-/ansi-html-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
       "dev": true
     },
     "ansi-regex": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
       "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
     },
     "ansicolors": {
       "version": "0.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/ansicolors/-/ansicolors-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
       "dev": true
     },
     "any-observable": {
       "version": "0.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/any-observable/-/any-observable-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
       "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
       "dev": true
     },
     "any-promise": {
       "version": "1.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/any-promise/-/any-promise-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
       "dev": true
     },
     "anymatch": {
       "version": "3.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/anymatch/-/anymatch-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
       "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
       "dev": true,
       "optional": true,
@@ -5896,13 +5941,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -5911,7 +5956,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -5928,7 +5973,7 @@
         },
         "glob": {
           "version": "7.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/glob/-/glob-7.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
           "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
           "dev": true,
           "requires": {
@@ -5948,7 +5993,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -5959,7 +6004,7 @@
     },
     "apollo-cache": {
       "version": "1.3.5",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-cache/-/apollo-cache-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
       "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
       "requires": {
         "apollo-utilities": "^1.3.4",
@@ -5978,7 +6023,7 @@
     },
     "apollo-cache-inmemory": {
       "version": "1.6.6",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
       "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
       "requires": {
         "apollo-cache": "^1.3.5",
@@ -6009,7 +6054,7 @@
     },
     "apollo-client": {
       "version": "2.6.10",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-client/-/apollo-client-2.6.10.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
       "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
       "requires": {
         "@types/zen-observable": "^0.8.0",
@@ -6082,7 +6127,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://npm.americanwhitewater.org:443/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -6139,7 +6184,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://npm.americanwhitewater.org:443/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -6220,7 +6265,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://npm.americanwhitewater.org:443/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -6238,7 +6283,7 @@
     },
     "apollo-env": {
       "version": "0.6.5",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-env/-/apollo-env-0.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.5.tgz",
       "integrity": "sha512-jeBUVsGymeTHYWp3me0R2CZRZrFeuSZeICZHCeRflHTfnQtlmbSXdy5E0pOyRM9CU4JfQkKDC98S1YglQj7Bzg==",
       "dev": true,
       "requires": {
@@ -6293,7 +6338,7 @@
     },
     "apollo-link": {
       "version": "1.2.14",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-link/-/apollo-link-1.2.14.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
       "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
       "requires": {
         "apollo-utilities": "^1.3.0",
@@ -6304,7 +6349,7 @@
     },
     "apollo-link-context": {
       "version": "1.0.20",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-link-context/-/apollo-link-context-1.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.20.tgz",
       "integrity": "sha512-MLLPYvhzNb8AglNsk2NcL9AvhO/Vc9hn2ZZuegbhRHGet3oGr0YH9s30NS9+ieoM0sGT11p7oZ6oAILM/kiRBA==",
       "requires": {
         "apollo-link": "^1.2.14",
@@ -6313,7 +6358,7 @@
     },
     "apollo-link-error": {
       "version": "1.1.13",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-link-error/-/apollo-link-error-1.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.13.tgz",
       "integrity": "sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==",
       "dev": true,
       "requires": {
@@ -6324,7 +6369,7 @@
     },
     "apollo-link-http": {
       "version": "1.5.17",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
       "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
       "dev": true,
       "requires": {
@@ -6335,7 +6380,7 @@
     },
     "apollo-link-http-common": {
       "version": "0.2.16",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
       "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
       "requires": {
         "apollo-link": "^1.2.14",
@@ -6345,7 +6390,7 @@
     },
     "apollo-link-persisted-queries": {
       "version": "0.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-link-persisted-queries/-/apollo-link-persisted-queries-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-link-persisted-queries/-/apollo-link-persisted-queries-0.2.2.tgz",
       "integrity": "sha512-YL7XBu/5QsSbbYaWUXgm87T2Hn/2AQZk5Wr8CLXGDr3Wl3E/TRhBhKgQQTly9xhaTi7jgBO+AeIyTH5wCBHA9w==",
       "dev": true,
       "requires": {
@@ -6355,7 +6400,7 @@
     },
     "apollo-link-state": {
       "version": "0.4.2",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-link-state/-/apollo-link-state-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-link-state/-/apollo-link-state-0.4.2.tgz",
       "integrity": "sha512-xMPcAfuiPVYXaLwC6oJFIZrKgV3GmdO31Ag2eufRoXpvT0AfJZjdaPB4450Nu9TslHRePN9A3quxNueILlQxlw==",
       "dev": true,
       "requires": {
@@ -6365,7 +6410,7 @@
     },
     "apollo-link-ws": {
       "version": "1.0.20",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-link-ws/-/apollo-link-ws-1.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.20.tgz",
       "integrity": "sha512-mjSFPlQxmoLArpHBeUb2Xj+2HDYeTaJqFGOqQ+I8NVJxgL9lJe84PDWcPah/yMLv3rB7QgBDSuZ0xoRFBPlySw==",
       "dev": true,
       "requires": {
@@ -6433,7 +6478,7 @@
         },
         "ws": {
           "version": "6.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ws/-/ws-6.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
           "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "dev": true,
           "requires": {
@@ -6529,7 +6574,7 @@
     },
     "apollo-upload-client": {
       "version": "13.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-upload-client/-/apollo-upload-client-13.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-13.0.0.tgz",
       "integrity": "sha512-lJ9/bk1BH1lD15WhWRha2J3+LrXrPIX5LP5EwiOUHv8PCORp4EUrcujrA3rI5hZeZygrTX8bshcuMdpqpSrvtA==",
       "requires": {
         "@babel/runtime": "^7.9.2",
@@ -6547,7 +6592,7 @@
     },
     "apollo-utilities": {
       "version": "1.3.4",
-      "resolved": "https://npm.americanwhitewater.org:443/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
       "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
       "requires": {
         "@wry/equality": "^0.1.2",
@@ -6568,7 +6613,7 @@
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/aproba/-/aproba-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
@@ -6580,7 +6625,7 @@
     },
     "are-we-there-yet": {
       "version": "1.1.5",
-      "resolved": "https://npm.americanwhitewater.org:443/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "requires": {
@@ -6590,13 +6635,13 @@
     },
     "arg": {
       "version": "4.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/arg/-/arg-4.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://npm.americanwhitewater.org:443/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
@@ -6605,48 +6650,48 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
     "array-find": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/array-find/-/array-find-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
       "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
       "version": "3.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/array-includes/-/array-includes-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
       "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
       "requires": {
         "define-properties": "^1.1.3",
@@ -6656,7 +6701,7 @@
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -6665,19 +6710,19 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "array.prototype.flat": {
       "version": "1.2.3",
-      "resolved": "https://npm.americanwhitewater.org:443/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
       "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
       "requires": {
         "define-properties": "^1.1.3",
@@ -6692,7 +6737,7 @@
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
@@ -6713,7 +6758,7 @@
       "dependencies": {
         "bn.js": {
           "version": "4.11.9",
-          "resolved": "https://npm.americanwhitewater.org:443/bn.js/-/bn.js-4.11.9.tgz",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
@@ -6721,7 +6766,7 @@
     },
     "assert": {
       "version": "1.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/assert/-/assert-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
       "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "dev": true,
       "requires": {
@@ -6731,13 +6776,13 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://npm.americanwhitewater.org:443/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -6748,13 +6793,13 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
@@ -6777,13 +6822,13 @@
     },
     "astral-regex": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/astral-regex/-/astral-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "async": {
       "version": "2.6.3",
-      "resolved": "https://npm.americanwhitewater.org:443/async/-/async-2.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
@@ -6792,25 +6837,25 @@
     },
     "async-each": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/async-each/-/async-each-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
     "async-foreach": {
       "version": "0.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/async-foreach/-/async-foreach-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
     },
     "async-limiter": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/async-limiter/-/async-limiter-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
     "async-retry": {
       "version": "1.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/async-retry/-/async-retry-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
       "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
       "dev": true,
       "requires": {
@@ -6819,7 +6864,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
@@ -6831,7 +6876,7 @@
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/atob/-/atob-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
@@ -6911,13 +6956,13 @@
     },
     "await-to-js": {
       "version": "2.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/await-to-js/-/await-to-js-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-2.1.1.tgz",
       "integrity": "sha512-CHBC6gQGCIzjZ09tJ+XmpQoZOn4GdWePB4qUweCaKNJ0D3f115YdhmYVTZ4rMVpiJ3cFzZcTYK1VMYEICV4YXw==",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://npm.americanwhitewater.org:443/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
@@ -6929,7 +6974,7 @@
     },
     "axios": {
       "version": "0.19.2",
-      "resolved": "https://npm.americanwhitewater.org:443/axios/-/axios-0.19.2.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
       "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "requires": {
         "follow-redirects": "1.5.10"
@@ -6937,7 +6982,7 @@
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
@@ -6948,19 +6993,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -6979,13 +7024,13 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/js-tokens/-/js-tokens-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -6994,7 +7039,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -7002,13 +7047,13 @@
     },
     "babel-core": {
       "version": "7.0.0-bridge.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
       "dev": true
     },
     "babel-eslint": {
       "version": "10.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
       "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
       "dev": true,
       "requires": {
@@ -7022,7 +7067,7 @@
     },
     "babel-extract-comments": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
       "integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
       "dev": true,
       "requires": {
@@ -7031,7 +7076,7 @@
     },
     "babel-jest": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-jest/-/babel-jest-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
       "integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
       "dev": true,
       "requires": {
@@ -7046,7 +7091,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -7055,7 +7100,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -7074,7 +7119,7 @@
     },
     "babel-loader": {
       "version": "8.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-loader/-/babel-loader-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
       "integrity": "sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==",
       "dev": true,
       "requires": {
@@ -7095,7 +7140,7 @@
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
@@ -7104,7 +7149,7 @@
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
       "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
       "dev": true,
       "requires": {
@@ -7113,7 +7158,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "5.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
       "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
       "dev": true,
       "requires": {
@@ -7170,7 +7215,7 @@
     },
     "babel-plugin-jest-hoist": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
       "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
       "dev": true,
       "requires": {
@@ -7179,13 +7224,13 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.2",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
@@ -7197,7 +7242,7 @@
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.26.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {
@@ -7207,7 +7252,7 @@
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
@@ -7217,7 +7262,7 @@
     },
     "babel-preset-jest": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
       "integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
       "dev": true,
       "requires": {
@@ -7227,7 +7272,7 @@
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
@@ -7237,13 +7282,13 @@
       "dependencies": {
         "core-js": {
           "version": "2.6.11",
-          "resolved": "https://npm.americanwhitewater.org:443/core-js/-/core-js-2.6.11.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
           "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
           "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "resolved": "https://npm.americanwhitewater.org:443/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
         }
@@ -7251,7 +7296,7 @@
     },
     "babel-template": {
       "version": "6.26.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-template/-/babel-template-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
@@ -7264,7 +7309,7 @@
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
@@ -7281,7 +7326,7 @@
       "dependencies": {
         "globals": {
           "version": "9.18.0",
-          "resolved": "https://npm.americanwhitewater.org:443/globals/-/globals-9.18.0.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
           "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
           "dev": true
         }
@@ -7289,7 +7334,7 @@
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
@@ -7301,7 +7346,7 @@
       "dependencies": {
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         }
@@ -7309,30 +7354,30 @@
     },
     "babylon": {
       "version": "6.18.0",
-      "resolved": "https://npm.americanwhitewater.org:443/babylon/-/babylon-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "backo2": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/backo2/-/backo2-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
     "bail": {
       "version": "1.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/bail/-/bail-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
       "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "https://npm.americanwhitewater.org:443/base/-/base-0.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
@@ -7347,7 +7392,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -7356,7 +7401,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
@@ -7365,7 +7410,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
@@ -7374,7 +7419,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
@@ -7393,19 +7438,19 @@
     },
     "base64-js": {
       "version": "1.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/base64-js/-/base64-js-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
     },
     "batch": {
       "version": "0.6.1",
-      "resolved": "https://npm.americanwhitewater.org:443/batch/-/batch-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
@@ -7414,7 +7459,7 @@
     },
     "bfj": {
       "version": "6.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/bfj/-/bfj-6.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
       "integrity": "sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==",
       "dev": true,
       "requires": {
@@ -7426,7 +7471,7 @@
     },
     "big.js": {
       "version": "5.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/big.js/-/big.js-5.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
     },
@@ -7439,7 +7484,7 @@
     },
     "bindings": {
       "version": "1.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/bindings/-/bindings-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
       "requires": {
@@ -7448,7 +7493,7 @@
     },
     "block-stream": {
       "version": "0.0.9",
-      "resolved": "https://npm.americanwhitewater.org:443/block-stream/-/block-stream-0.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
@@ -7457,7 +7502,7 @@
     },
     "bluebird": {
       "version": "3.7.2",
-      "resolved": "https://npm.americanwhitewater.org:443/bluebird/-/bluebird-3.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
@@ -7469,7 +7514,7 @@
     },
     "body-parser": {
       "version": "1.19.0",
-      "resolved": "https://npm.americanwhitewater.org:443/body-parser/-/body-parser-1.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "requires": {
         "bytes": "3.1.0",
@@ -7486,7 +7531,7 @@
     },
     "bonjour": {
       "version": "3.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/bonjour/-/bonjour-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "dev": true,
       "requires": {
@@ -7500,7 +7545,7 @@
       "dependencies": {
         "array-flatten": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/array-flatten/-/array-flatten-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
           "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
           "dev": true
         }
@@ -7508,13 +7553,13 @@
     },
     "boolbase": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/boolbase/-/boolbase-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
     "boxen": {
       "version": "1.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/boxen/-/boxen-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
@@ -7529,7 +7574,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -7538,13 +7583,13 @@
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -7572,7 +7617,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://npm.americanwhitewater.org:443/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
@@ -7581,7 +7626,7 @@
     },
     "braces": {
       "version": "2.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/braces/-/braces-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
@@ -7599,7 +7644,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -7616,19 +7661,19 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
     "browser-resolve": {
       "version": "1.11.3",
-      "resolved": "https://npm.americanwhitewater.org:443/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
       "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
       "dev": true,
       "requires": {
@@ -7637,7 +7682,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "https://npm.americanwhitewater.org:443/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
@@ -7645,7 +7690,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -7659,7 +7704,7 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
@@ -7670,7 +7715,7 @@
     },
     "browserify-des": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/browserify-des/-/browserify-des-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
@@ -7682,7 +7727,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -7692,7 +7737,7 @@
       "dependencies": {
         "bn.js": {
           "version": "4.11.9",
-          "resolved": "https://npm.americanwhitewater.org:443/bn.js/-/bn.js-4.11.9.tgz",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
@@ -7717,7 +7762,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://npm.americanwhitewater.org:443/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
@@ -7728,7 +7773,7 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
         }
@@ -7736,7 +7781,7 @@
     },
     "browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
@@ -7757,7 +7802,7 @@
     },
     "bs-logger": {
       "version": "0.2.6",
-      "resolved": "https://npm.americanwhitewater.org:443/bs-logger/-/bs-logger-0.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
       "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
       "dev": true,
       "requires": {
@@ -7766,7 +7811,7 @@
     },
     "bser": {
       "version": "2.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/bser/-/bser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dev": true,
       "requires": {
@@ -7775,7 +7820,7 @@
     },
     "buffer": {
       "version": "4.9.2",
-      "resolved": "https://npm.americanwhitewater.org:443/buffer/-/buffer-4.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dev": true,
       "requires": {
@@ -7786,36 +7831,36 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-indexof": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
       "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
       "dev": true
     },
     "buffer-json": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/buffer-json/-/buffer-json-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-json/-/buffer-json-2.0.0.tgz",
       "integrity": "sha512-+jjPFVqyfF1esi9fvfUs3NqM0pH1ziZ36VP4hmA/y/Ssfo/5w5xHKfTw9BwQjoJ1w/oVtpLomqwUHKdefGyuHw==",
       "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
     "busboy": {
       "version": "0.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/busboy/-/busboy-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
       "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
       "dev": true,
       "requires": {
@@ -7824,18 +7869,18 @@
     },
     "byline": {
       "version": "5.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/byline/-/byline-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
       "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
       "dev": true
     },
     "bytes": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/bytes/-/bytes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "cacache": {
       "version": "12.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/cacache/-/cacache-12.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
       "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
       "dev": true,
       "requires": {
@@ -7858,7 +7903,7 @@
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/cache-base/-/cache-base-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
@@ -7883,7 +7928,7 @@
     },
     "cache-loader": {
       "version": "4.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/cache-loader/-/cache-loader-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cache-loader/-/cache-loader-4.1.0.tgz",
       "integrity": "sha512-ftOayxve0PwKzBF/GLsZNC9fJBXl8lkZE3TOsjkboHfVHVkL39iUEs1FO07A33mizmci5Dudt38UZrrYXDtbhw==",
       "dev": true,
       "requires": {
@@ -7897,7 +7942,7 @@
       "dependencies": {
         "find-cache-dir": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
           "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
           "dev": true,
           "requires": {
@@ -7908,7 +7953,7 @@
         },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/find-up/-/find-up-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
@@ -7918,7 +7963,7 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/locate-path/-/locate-path-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
@@ -7927,7 +7972,7 @@
         },
         "make-dir": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/make-dir/-/make-dir-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
           "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
@@ -7945,7 +7990,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/p-locate/-/p-locate-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
@@ -7960,13 +8005,13 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/path-exists/-/path-exists-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
         "pkg-dir": {
           "version": "4.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
           "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
           "dev": true,
           "requires": {
@@ -7975,7 +8020,7 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -7992,13 +8037,13 @@
     },
     "call-me-maybe": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
       "dev": true
     },
     "caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
@@ -8007,7 +8052,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -8015,7 +8060,7 @@
     },
     "caller-path": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/caller-path/-/caller-path-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
@@ -8024,13 +8069,13 @@
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/camel-case/-/camel-case-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
@@ -8046,7 +8091,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -8056,7 +8101,7 @@
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/camelcase/-/camelcase-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
           "dev": true
         }
@@ -8064,7 +8109,7 @@
     },
     "caniuse-api": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/caniuse-api/-/caniuse-api-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "dev": true,
       "requires": {
@@ -8114,7 +8159,7 @@
     },
     "capture-exit": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/capture-exit/-/capture-exit-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
       "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
       "dev": true,
       "requires": {
@@ -8123,7 +8168,7 @@
     },
     "capture-stack-trace": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
       "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
       "dev": true
     },
@@ -8139,14 +8184,14 @@
       "dependencies": {
         "flatpickr": {
           "version": "4.6.1",
-          "resolved": "https://npm.americanwhitewater.org:443/flatpickr/-/flatpickr-4.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.1.tgz",
           "integrity": "sha512-3ULSxbXmcMIRzer/2jLNweoqHpwDvsjEawO2FUd9UFR8uPwLM+LruZcPDpuZStcEgbQKhuFOfXo4nYdGladSNw=="
         }
       }
     },
     "cardinal": {
       "version": "2.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/cardinal/-/cardinal-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
       "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
       "dev": true,
       "requires": {
@@ -8156,13 +8201,13 @@
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
       "integrity": "sha512-/4YgnZS8y1UXXmC02xD5rRrBEu6T5ub+mQHLNRj0fzTRbgdBYhsNo2V5EqwgqrExjxsjtF/OpAKAMkKsxbD5XQ==",
       "dev": true
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://npm.americanwhitewater.org:443/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
@@ -8174,7 +8219,7 @@
     },
     "chalk": {
       "version": "0.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
       "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
       "requires": {
         "ansi-styles": "~1.0.0",
@@ -8245,31 +8290,31 @@
     },
     "character-entities": {
       "version": "1.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/character-entities/-/character-entities-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
       "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
       "dev": true
     },
     "character-entities-html4": {
       "version": "1.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
       "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
       "dev": true
     },
     "character-entities-legacy": {
       "version": "1.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
       "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
       "dev": true
     },
     "character-reference-invalid": {
       "version": "1.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
       "dev": true
     },
     "chardet": {
       "version": "0.7.0",
-      "resolved": "https://npm.americanwhitewater.org:443/chardet/-/chardet-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
@@ -8284,7 +8329,7 @@
     },
     "chartjs-color": {
       "version": "2.4.1",
-      "resolved": "https://npm.americanwhitewater.org:443/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
       "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
       "requires": {
         "chartjs-color-string": "^0.6.0",
@@ -8293,7 +8338,7 @@
     },
     "chartjs-color-string": {
       "version": "0.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
       "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
       "requires": {
         "color-name": "^1.0.0"
@@ -8301,7 +8346,7 @@
     },
     "check-types": {
       "version": "8.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/check-types/-/check-types-8.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
       "integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==",
       "dev": true
     },
@@ -8324,7 +8369,7 @@
       "dependencies": {
         "braces": {
           "version": "3.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/braces/-/braces-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
           "optional": true,
@@ -8334,7 +8379,7 @@
         },
         "fill-range": {
           "version": "7.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/fill-range/-/fill-range-7.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "optional": true,
@@ -8344,14 +8389,14 @@
         },
         "is-number": {
           "version": "7.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-number/-/is-number-7.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true,
           "optional": true
         },
         "to-regex-range": {
           "version": "5.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "optional": true,
@@ -8363,13 +8408,13 @@
     },
     "chownr": {
       "version": "1.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/chownr/-/chownr-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
     "chrome-trace-event": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
       "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "dev": true,
       "requires": {
@@ -8378,13 +8423,13 @@
     },
     "ci-info": {
       "version": "1.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/ci-info/-/ci-info-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/cipher-base/-/cipher-base-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
@@ -8394,7 +8439,7 @@
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "https://npm.americanwhitewater.org:443/class-utils/-/class-utils-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
@@ -8406,7 +8451,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://npm.americanwhitewater.org:443/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -8423,7 +8468,7 @@
     },
     "clean-css": {
       "version": "4.2.3",
-      "resolved": "https://npm.americanwhitewater.org:443/clean-css/-/clean-css-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
       "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
       "dev": true,
       "requires": {
@@ -8432,19 +8477,19 @@
     },
     "clean-stack": {
       "version": "2.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/clean-stack/-/clean-stack-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
     "cli-boxes": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
@@ -8453,7 +8498,7 @@
     },
     "cli-highlight": {
       "version": "2.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/cli-highlight/-/cli-highlight-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.4.tgz",
       "integrity": "sha512-s7Zofobm20qriqDoU9sXptQx0t2R9PEgac92mENNm7xaEe1hn71IIMsXMK+6encA6WRCWWxIGQbipr3q998tlQ==",
       "dev": true,
       "requires": {
@@ -8467,7 +8512,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
@@ -8488,7 +8533,7 @@
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
@@ -8498,7 +8543,7 @@
         },
         "cliui": {
           "version": "6.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/cliui/-/cliui-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
           "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
           "dev": true,
           "requires": {
@@ -8509,7 +8554,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -8518,7 +8563,7 @@
         },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/find-up/-/find-up-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
@@ -8528,7 +8573,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
@@ -8540,13 +8585,13 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/locate-path/-/locate-path-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
@@ -8564,7 +8609,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/p-locate/-/p-locate-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
@@ -8579,19 +8624,19 @@
         },
         "parse5": {
           "version": "5.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/parse5/-/parse5-5.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
           "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
           "dev": true
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/path-exists/-/path-exists-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
@@ -8602,7 +8647,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -8620,7 +8665,7 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
           "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "requires": {
@@ -8650,7 +8695,7 @@
         },
         "yargs-parser": {
           "version": "18.1.3",
-          "resolved": "https://npm.americanwhitewater.org:443/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
           "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
@@ -8662,7 +8707,7 @@
     },
     "cli-progress": {
       "version": "3.8.2",
-      "resolved": "https://npm.americanwhitewater.org:443/cli-progress/-/cli-progress-3.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.8.2.tgz",
       "integrity": "sha512-qRwBxLldMSfxB+YGFgNRaj5vyyHe1yMpVeDL79c+7puGujdKJHQHydgqXDcrkvQgJ5U/d3lpf6vffSoVVUftVQ==",
       "dev": true,
       "requires": {
@@ -8672,19 +8717,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
@@ -8695,7 +8740,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -8712,7 +8757,7 @@
     },
     "cli-truncate": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
       "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
       "dev": true,
       "requires": {
@@ -8722,7 +8767,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
@@ -8737,13 +8782,13 @@
         },
         "astral-regex": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/astral-regex/-/astral-regex-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
           "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
           "dev": true
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -8752,13 +8797,13 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "slice-ansi": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/slice-ansi/-/slice-ansi-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
           "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
           "dev": true,
           "requires": {
@@ -8769,7 +8814,7 @@
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
@@ -8780,7 +8825,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -8859,7 +8904,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -8974,7 +9019,7 @@
     },
     "clipboardy": {
       "version": "2.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/clipboardy/-/clipboardy-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
       "integrity": "sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==",
       "dev": true,
       "requires": {
@@ -8985,7 +9030,7 @@
       "dependencies": {
         "is-wsl": {
           "version": "2.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-wsl/-/is-wsl-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
           "dev": true,
           "requires": {
@@ -8996,7 +9041,7 @@
     },
     "cliui": {
       "version": "5.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/cliui/-/cliui-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
@@ -9007,19 +9052,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
@@ -9030,7 +9075,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -9041,13 +9086,13 @@
     },
     "clone": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/clone/-/clone-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "clone-deep": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/clone-deep/-/clone-deep-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
       "dev": true,
       "requires": {
@@ -9075,7 +9120,7 @@
     },
     "clone-regexp": {
       "version": "2.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
       "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
       "dev": true,
       "requires": {
@@ -9084,7 +9129,7 @@
       "dependencies": {
         "is-regexp": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-regexp/-/is-regexp-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
           "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
           "dev": true
         }
@@ -9092,13 +9137,13 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "coa": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/coa/-/coa-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
       "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
       "dev": true,
       "requires": {
@@ -9109,7 +9154,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -9118,7 +9163,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -9137,19 +9182,19 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "collapse-white-space": {
       "version": "1.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
       "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
       "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -9169,7 +9214,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-1.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "requires": {
         "color-name": "1.1.3"
@@ -9177,14 +9222,14 @@
       "dependencies": {
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://npm.americanwhitewater.org:443/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         }
       }
     },
     "color-name": {
       "version": "1.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-string": {
@@ -9204,13 +9249,13 @@
     },
     "colors": {
       "version": "1.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/colors/-/colors-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://npm.americanwhitewater.org:443/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
@@ -9219,31 +9264,31 @@
     },
     "commander": {
       "version": "2.20.3",
-      "resolved": "https://npm.americanwhitewater.org:443/commander/-/commander-2.20.3.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
     "common-tags": {
       "version": "1.8.0",
-      "resolved": "https://npm.americanwhitewater.org:443/common-tags/-/common-tags-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
       "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
       "dev": true
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/component-emitter/-/component-emitter-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
     "compressible": {
       "version": "2.0.18",
-      "resolved": "https://npm.americanwhitewater.org:443/compressible/-/compressible-2.0.18.tgz",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "dev": true,
       "requires": {
@@ -9252,7 +9297,7 @@
     },
     "compression": {
       "version": "1.7.4",
-      "resolved": "https://npm.americanwhitewater.org:443/compression/-/compression-1.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
       "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
       "dev": true,
       "requires": {
@@ -9267,7 +9312,7 @@
       "dependencies": {
         "bytes": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/bytes/-/bytes-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
           "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
           "dev": true
         }
@@ -9280,12 +9325,12 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://npm.americanwhitewater.org:443/concat-stream/-/concat-stream-1.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
         "buffer-from": "^1.0.0",
@@ -9296,7 +9341,7 @@
     },
     "condense-newlines": {
       "version": "0.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/condense-newlines/-/condense-newlines-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/condense-newlines/-/condense-newlines-0.2.1.tgz",
       "integrity": "sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=",
       "dev": true,
       "requires": {
@@ -9307,7 +9352,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -9316,13 +9361,13 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "https://npm.americanwhitewater.org:443/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.americanwhitewater.org:443/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -9333,7 +9378,7 @@
     },
     "config-chain": {
       "version": "1.1.12",
-      "resolved": "https://npm.americanwhitewater.org:443/config-chain/-/config-chain-1.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
       "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
       "requires": {
@@ -9366,7 +9411,7 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/make-dir/-/make-dir-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
           "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "dev": true,
           "requires": {
@@ -9375,7 +9420,7 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -9383,25 +9428,25 @@
     },
     "connect-history-api-fallback": {
       "version": "1.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
       "dev": true
     },
     "console-browserify": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/console-browserify/-/console-browserify-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "consolidate": {
       "version": "0.15.1",
-      "resolved": "https://npm.americanwhitewater.org:443/consolidate/-/consolidate-0.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.15.1.tgz",
       "integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
       "dev": true,
       "requires": {
@@ -9451,18 +9496,18 @@
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
     "contains-path": {
       "version": "0.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/contains-path/-/contains-path-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
     },
     "content-disposition": {
       "version": "0.5.3",
-      "resolved": "https://npm.americanwhitewater.org:443/content-disposition/-/content-disposition-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
       "requires": {
         "safe-buffer": "5.1.2"
@@ -9470,12 +9515,12 @@
     },
     "content-type": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/content-type/-/content-type-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.7.0",
-      "resolved": "https://npm.americanwhitewater.org:443/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "requires": {
@@ -9484,17 +9529,17 @@
     },
     "cookie": {
       "version": "0.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/cookie/-/cookie-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "copy-concurrently": {
       "version": "1.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
@@ -9508,7 +9553,7 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
@@ -9534,7 +9579,7 @@
       "dependencies": {
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -9544,7 +9589,7 @@
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
-              "resolved": "https://npm.americanwhitewater.org:443/is-glob/-/is-glob-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
@@ -9555,7 +9600,7 @@
         },
         "globby": {
           "version": "7.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/globby/-/globby-7.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
           "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
           "dev": true,
           "requires": {
@@ -9569,7 +9614,7 @@
         },
         "ignore": {
           "version": "3.3.10",
-          "resolved": "https://npm.americanwhitewater.org:443/ignore/-/ignore-3.3.10.tgz",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
           "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
           "dev": true
         },
@@ -9590,13 +9635,13 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/schema-utils/-/schema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
@@ -9607,7 +9652,7 @@
         },
         "slash": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/slash/-/slash-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
           "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
           "dev": true
         }
@@ -9630,7 +9675,7 @@
       "dependencies": {
         "semver": {
           "version": "7.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-7.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
           "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
           "dev": true
         }
@@ -9638,12 +9683,12 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
       "version": "2.8.5",
-      "resolved": "https://npm.americanwhitewater.org:443/cors/-/cors-2.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dev": true,
       "requires": {
@@ -9653,7 +9698,7 @@
     },
     "cosmiconfig": {
       "version": "5.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
       "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
       "dev": true,
       "requires": {
@@ -9665,7 +9710,7 @@
       "dependencies": {
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -9677,7 +9722,7 @@
     },
     "coveralls": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/coveralls/-/coveralls-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
       "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
       "dev": true,
       "requires": {
@@ -9690,7 +9735,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.5",
-          "resolved": "https://npm.americanwhitewater.org:443/minimist/-/minimist-1.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
@@ -9708,7 +9753,7 @@
       "dependencies": {
         "bn.js": {
           "version": "4.11.9",
-          "resolved": "https://npm.americanwhitewater.org:443/bn.js/-/bn.js-4.11.9.tgz",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
@@ -9716,7 +9761,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/create-error-class/-/create-error-class-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
@@ -9725,7 +9770,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -9738,7 +9783,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://npm.americanwhitewater.org:443/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -9752,7 +9797,7 @@
     },
     "cross-spawn": {
       "version": "6.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
@@ -9765,7 +9810,7 @@
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "https://npm.americanwhitewater.org:443/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
@@ -9784,13 +9829,13 @@
     },
     "crypto-random-string": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
     "css": {
       "version": "2.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/css/-/css-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
       "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
       "dev": true,
       "requires": {
@@ -9802,13 +9847,13 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
     "css-declaration-sorter": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
       "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
       "dev": true,
       "requires": {
@@ -9877,7 +9922,7 @@
     },
     "css-loader": {
       "version": "3.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/css-loader/-/css-loader-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
       "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
       "dev": true,
       "requires": {
@@ -9952,7 +9997,7 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         },
@@ -9969,7 +10014,7 @@
     },
     "css-select": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/css-select/-/css-select-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
       "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
       "dev": true,
       "requires": {
@@ -9999,13 +10044,13 @@
         },
         "domelementtype": {
           "version": "1.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/domelementtype/-/domelementtype-1.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
           "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
           "dev": true
         },
         "domutils": {
           "version": "1.7.0",
-          "resolved": "https://npm.americanwhitewater.org:443/domutils/-/domutils-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
           "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
           "dev": true,
           "requires": {
@@ -10017,13 +10062,13 @@
     },
     "css-select-base-adapter": {
       "version": "0.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
       "dev": true
     },
     "css-tree": {
       "version": "1.0.0-alpha.37",
-      "resolved": "https://npm.americanwhitewater.org:443/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
       "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
       "dev": true,
       "requires": {
@@ -10039,24 +10084,24 @@
     },
     "csscolorparser": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
       "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
     },
     "cssesc": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/cssesc/-/cssesc-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
     "cssfilter": {
       "version": "0.0.10",
-      "resolved": "https://npm.americanwhitewater.org:443/cssfilter/-/cssfilter-0.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=",
       "dev": true
     },
     "cssnano": {
       "version": "4.1.10",
-      "resolved": "https://npm.americanwhitewater.org:443/cssnano/-/cssnano-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
       "integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
       "dev": true,
       "requires": {
@@ -10127,7 +10172,7 @@
     },
     "cssnano-preset-default": {
       "version": "4.0.7",
-      "resolved": "https://npm.americanwhitewater.org:443/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
       "integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
       "dev": true,
       "requires": {
@@ -10224,19 +10269,19 @@
     },
     "cssnano-util-get-arguments": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
       "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
       "dev": true
     },
     "cssnano-util-get-match": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
       "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
       "dev": true
     },
     "cssnano-util-raw-cache": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
       "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
       "dev": true,
       "requires": {
@@ -10304,7 +10349,7 @@
     },
     "cssnano-util-same-parent": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
       "integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==",
       "dev": true
     },
@@ -10337,13 +10382,13 @@
     },
     "cssom": {
       "version": "0.3.8",
-      "resolved": "https://npm.americanwhitewater.org:443/cssom/-/cssom-0.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
     },
     "cssstyle": {
       "version": "1.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/cssstyle/-/cssstyle-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
       "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
       "dev": true,
       "requires": {
@@ -10352,7 +10397,7 @@
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "https://npm.americanwhitewater.org:443/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
@@ -10361,18 +10406,18 @@
     },
     "cyclist": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/cyclist/-/cyclist-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
     "d3-array": {
       "version": "1.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/d3-array/-/d3-array-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
     },
     "d3-geo": {
       "version": "1.7.1",
-      "resolved": "https://npm.americanwhitewater.org:443/d3-geo/-/d3-geo-1.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
       "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
       "requires": {
         "d3-array": "1"
@@ -10380,7 +10425,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://npm.americanwhitewater.org:443/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -10389,7 +10434,7 @@
     },
     "data-urls": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/data-urls/-/data-urls-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
       "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
       "dev": true,
       "requires": {
@@ -10400,7 +10445,7 @@
       "dependencies": {
         "whatwg-url": {
           "version": "7.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
           "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
           "dev": true,
           "requires": {
@@ -10413,13 +10458,13 @@
     },
     "date-fns": {
       "version": "1.30.1",
-      "resolved": "https://npm.americanwhitewater.org:443/date-fns/-/date-fns-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
     },
     "de-indent": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/de-indent/-/de-indent-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
       "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
       "dev": true
     },
@@ -10443,13 +10488,13 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
@@ -10459,19 +10504,19 @@
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "dedent": {
       "version": "0.7.0",
-      "resolved": "https://npm.americanwhitewater.org:443/dedent/-/dedent-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "deep-equal": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/deep-equal/-/deep-equal-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
       "dev": true,
       "requires": {
@@ -10485,24 +10530,24 @@
     },
     "deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/deep-extend/-/deep-extend-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "deepmerge": {
       "version": "4.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/deepmerge/-/deepmerge-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "default-gateway": {
       "version": "5.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/default-gateway/-/default-gateway-5.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.5.tgz",
       "integrity": "sha512-z2RnruVmj8hVMmAnEJMTIJNijhKCDiGjbLP+BHJFOT7ld3Bo5qcIBpVYDniqhbMIIf+jZDlkP2MkPXiQy/DBLA==",
       "dev": true,
       "requires": {
@@ -10511,7 +10556,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "7.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
           "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
@@ -10522,7 +10567,7 @@
         },
         "execa": {
           "version": "3.4.0",
-          "resolved": "https://npm.americanwhitewater.org:443/execa/-/execa-3.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
           "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
           "dev": true,
           "requires": {
@@ -10549,19 +10594,19 @@
         },
         "is-stream": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-stream/-/is-stream-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
           "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "npm-run-path": {
           "version": "4.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
           "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
           "dev": true,
           "requires": {
@@ -10579,19 +10624,19 @@
         },
         "p-finally": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/p-finally/-/p-finally-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
           "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
           "dev": true
         },
         "path-key": {
           "version": "3.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/path-key/-/path-key-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
         "shebang-command": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/shebang-command/-/shebang-command-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
@@ -10600,13 +10645,13 @@
         },
         "shebang-regex": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
         "which": {
           "version": "2.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/which/-/which-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
@@ -10617,7 +10662,7 @@
     },
     "defaults": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/defaults/-/defaults-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
@@ -10626,7 +10671,7 @@
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/define-properties/-/define-properties-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
         "object-keys": "^1.0.12"
@@ -10634,7 +10679,7 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/define-property/-/define-property-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
@@ -10644,7 +10689,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
@@ -10653,7 +10698,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
@@ -10662,7 +10707,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
@@ -10681,7 +10726,7 @@
     },
     "del": {
       "version": "4.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/del/-/del-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
       "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
       "dev": true,
       "requires": {
@@ -10696,7 +10741,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -10709,7 +10754,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://npm.americanwhitewater.org:443/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -10717,7 +10762,7 @@
         },
         "p-map": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/p-map/-/p-map-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
           "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
           "dev": true
         },
@@ -10731,30 +10776,30 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "delegates": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/delegates/-/delegates-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "deprecated-decorator": {
       "version": "0.1.6",
-      "resolved": "https://npm.americanwhitewater.org:443/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
       "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=",
       "dev": true
     },
     "des.js": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/des.js/-/des.js-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
       "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
       "dev": true,
       "requires": {
@@ -10764,24 +10809,24 @@
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-newline": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/detect-newline/-/detect-newline-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
     "detect-node": {
       "version": "2.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/detect-node/-/detect-node-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
       "dev": true
     },
     "dicer": {
       "version": "0.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/dicer/-/dicer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
       "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
       "dev": true,
       "requires": {
@@ -10790,19 +10835,19 @@
     },
     "diff": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/diff/-/diff-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "diff-sequences": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/diff-sequences/-/diff-sequences-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
       "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
       "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -10813,7 +10858,7 @@
       "dependencies": {
         "bn.js": {
           "version": "4.11.9",
-          "resolved": "https://npm.americanwhitewater.org:443/bn.js/-/bn.js-4.11.9.tgz",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
@@ -10821,7 +10866,7 @@
     },
     "dir-glob": {
       "version": "2.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/dir-glob/-/dir-glob-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
       "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
       "dev": true,
       "requires": {
@@ -10847,13 +10892,13 @@
     },
     "dns-equal": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/dns-equal/-/dns-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
       "dev": true
     },
     "dns-packet": {
       "version": "1.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/dns-packet/-/dns-packet-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "dev": true,
       "requires": {
@@ -10863,7 +10908,7 @@
     },
     "dns-txt": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/dns-txt/-/dns-txt-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "dev": true,
       "requires": {
@@ -10881,7 +10926,7 @@
     },
     "dom-converter": {
       "version": "0.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/dom-converter/-/dom-converter-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "dev": true,
       "requires": {
@@ -10890,7 +10935,7 @@
     },
     "dom-event-types": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/dom-event-types/-/dom-event-types-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/dom-event-types/-/dom-event-types-1.0.0.tgz",
       "integrity": "sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==",
       "dev": true
     },
@@ -10906,7 +10951,7 @@
     },
     "domain-browser": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/domain-browser/-/domain-browser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
@@ -10917,7 +10962,7 @@
     },
     "domexception": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/domexception/-/domexception-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "dev": true,
       "requires": {
@@ -10984,7 +11029,7 @@
       "dependencies": {
         "is-obj": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-obj/-/is-obj-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
           "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
           "dev": true
         }
@@ -10992,13 +11037,13 @@
     },
     "dotenv": {
       "version": "8.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/dotenv/-/dotenv-8.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
       "dev": true
     },
     "dotenv-expand": {
       "version": "5.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
     },
@@ -11010,13 +11055,13 @@
     },
     "duplexer3": {
       "version": "0.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/duplexer3/-/duplexer3-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
-      "resolved": "https://npm.americanwhitewater.org:443/duplexify/-/duplexify-3.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
       "requires": {
@@ -11028,18 +11073,18 @@
     },
     "earcut": {
       "version": "2.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/earcut/-/earcut-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
       "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
     },
     "easy-stack": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/easy-stack/-/easy-stack-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.0.tgz",
       "integrity": "sha1-EskbMIWjfwuqM26UhurEv5Tj54g=",
       "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
@@ -11049,7 +11094,7 @@
     },
     "editorconfig": {
       "version": "0.15.3",
-      "resolved": "https://npm.americanwhitewater.org:443/editorconfig/-/editorconfig-0.15.3.tgz",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
       "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
       "dev": true,
       "requires": {
@@ -11061,7 +11106,7 @@
       "dependencies": {
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/lru-cache/-/lru-cache-4.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
@@ -11071,7 +11116,7 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -11079,12 +11124,12 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "ejs": {
       "version": "2.7.4",
-      "resolved": "https://npm.americanwhitewater.org:443/ejs/-/ejs-2.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
       "dev": true
     },
@@ -11096,13 +11141,13 @@
     },
     "elegant-spinner": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
     "elliptic": {
       "version": "6.5.3",
-      "resolved": "https://npm.americanwhitewater.org:443/elliptic/-/elliptic-6.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
       "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
@@ -11117,7 +11162,7 @@
       "dependencies": {
         "bn.js": {
           "version": "4.11.9",
-          "resolved": "https://npm.americanwhitewater.org:443/bn.js/-/bn.js-4.11.9.tgz",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
@@ -11125,24 +11170,24 @@
     },
     "emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "emojis-list": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/emojis-list/-/emojis-list-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "resolved": "https://npm.americanwhitewater.org:443/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
@@ -11162,7 +11207,7 @@
       "dependencies": {
         "memory-fs": {
           "version": "0.5.0",
-          "resolved": "https://npm.americanwhitewater.org:443/memory-fs/-/memory-fs-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
           "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
           "dev": true,
           "requires": {
@@ -11196,7 +11241,7 @@
     },
     "env-ci": {
       "version": "3.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/env-ci/-/env-ci-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-3.2.2.tgz",
       "integrity": "sha512-AOiNZ3lmxrtva3r/roqaYDF+1PX2V+ouUzuGqJf7KNxyyYkuU+CsfFbbUeibQPdixxjI/lP6eDtvtkX1/wymJw==",
       "dev": true,
       "requires": {
@@ -11206,7 +11251,7 @@
     },
     "errno": {
       "version": "0.1.7",
-      "resolved": "https://npm.americanwhitewater.org:443/errno/-/errno-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
@@ -11215,7 +11260,7 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -11223,7 +11268,7 @@
     },
     "error-stack-parser": {
       "version": "2.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
       "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
       "dev": true,
       "requires": {
@@ -11250,7 +11295,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "requires": {
         "is-callable": "^1.1.4",
@@ -11266,7 +11311,7 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
@@ -11276,7 +11321,7 @@
     },
     "escodegen": {
       "version": "1.14.3",
-      "resolved": "https://npm.americanwhitewater.org:443/escodegen/-/escodegen-1.14.3.tgz",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
       "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "dev": true,
       "requires": {
@@ -11339,7 +11384,7 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
@@ -11354,7 +11399,7 @@
         },
         "chalk": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
@@ -11364,7 +11409,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -11373,7 +11418,7 @@
         },
         "cross-spawn": {
           "version": "7.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
           "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
@@ -11423,7 +11468,7 @@
         },
         "globals": {
           "version": "12.4.0",
-          "resolved": "https://npm.americanwhitewater.org:443/globals/-/globals-12.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
           "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
           "dev": true,
           "requires": {
@@ -11432,7 +11477,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
@@ -11448,7 +11493,7 @@
         },
         "levn": {
           "version": "0.4.1",
-          "resolved": "https://npm.americanwhitewater.org:443/levn/-/levn-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
           "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
           "dev": true,
           "requires": {
@@ -11458,13 +11503,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "optionator": {
           "version": "0.9.1",
-          "resolved": "https://npm.americanwhitewater.org:443/optionator/-/optionator-0.9.1.tgz",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
           "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
           "dev": true,
           "requires": {
@@ -11478,31 +11523,31 @@
         },
         "path-key": {
           "version": "3.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/path-key/-/path-key-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
         "prelude-ls": {
           "version": "1.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
           "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
           "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/resolve-from/-/resolve-from-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
         "semver": {
           "version": "7.3.2",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-7.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         },
         "shebang-command": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/shebang-command/-/shebang-command-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
@@ -11511,13 +11556,13 @@
         },
         "shebang-regex": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -11526,7 +11571,7 @@
         },
         "strip-json-comments": {
           "version": "3.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
           "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
         },
@@ -11541,7 +11586,7 @@
         },
         "type-check": {
           "version": "0.4.0",
-          "resolved": "https://npm.americanwhitewater.org:443/type-check/-/type-check-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
           "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
           "dev": true,
           "requires": {
@@ -11550,13 +11595,13 @@
         },
         "type-fest": {
           "version": "0.8.1",
-          "resolved": "https://npm.americanwhitewater.org:443/type-fest/-/type-fest-0.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
           "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
           "dev": true
         },
         "which": {
           "version": "2.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/which/-/which-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
@@ -11567,13 +11612,13 @@
     },
     "eslint-config-standard": {
       "version": "14.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
       "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
       "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.4",
-      "resolved": "https://npm.americanwhitewater.org:443/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
       "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
       "requires": {
         "debug": "^2.6.9",
@@ -11582,7 +11627,7 @@
     },
     "eslint-import-resolver-webpack": {
       "version": "0.12.2",
-      "resolved": "https://npm.americanwhitewater.org:443/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.12.2.tgz",
       "integrity": "sha512-7Jnm4YAoNNkvqPaZkKdIHsKGmv8/uNnYC5QsXkiSodvX4XEEfH2AKOna98FK52fCDXm3q4HzuX+7pRMKkJ64EQ==",
       "dev": true,
       "requires": {
@@ -11600,7 +11645,7 @@
       "dependencies": {
         "enhanced-resolve": {
           "version": "0.9.1",
-          "resolved": "https://npm.americanwhitewater.org:443/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
           "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
           "dev": true,
           "requires": {
@@ -11611,13 +11656,13 @@
         },
         "memory-fs": {
           "version": "0.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/memory-fs/-/memory-fs-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
           "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
           "dev": true
         },
         "tapable": {
           "version": "0.1.10",
-          "resolved": "https://npm.americanwhitewater.org:443/tapable/-/tapable-0.1.10.tgz",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
           "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
           "dev": true
         }
@@ -11625,7 +11670,7 @@
     },
     "eslint-loader": {
       "version": "2.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/eslint-loader/-/eslint-loader-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.2.1.tgz",
       "integrity": "sha512-RLgV9hoCVsMLvOxCuNjdqOrUqIj9oJg8hF44vzJaYqsAHuY9G2YAeN3joQ9nxP0p5Th9iFSIpKo+SD8KISxXRg==",
       "dev": true,
       "requires": {
@@ -11638,7 +11683,7 @@
     },
     "eslint-module-utils": {
       "version": "2.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
       "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
       "requires": {
         "debug": "^2.6.9",
@@ -11647,7 +11692,7 @@
     },
     "eslint-plugin-es": {
       "version": "3.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
       "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
       "dev": true,
       "requires": {
@@ -11677,7 +11722,7 @@
     },
     "eslint-plugin-node": {
       "version": "11.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
       "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
       "dev": true,
       "requires": {
@@ -11691,13 +11736,13 @@
       "dependencies": {
         "ignore": {
           "version": "5.1.8",
-          "resolved": "https://npm.americanwhitewater.org:443/ignore/-/ignore-5.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
           "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
           "dev": true
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -11705,7 +11750,7 @@
     },
     "eslint-plugin-prettier": {
       "version": "3.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
       "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
       "dev": true,
       "requires": {
@@ -11714,7 +11759,7 @@
     },
     "eslint-plugin-promise": {
       "version": "4.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
       "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
       "dev": true
     },
@@ -11746,7 +11791,7 @@
     },
     "eslint-scope": {
       "version": "4.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
       "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
@@ -11756,7 +11801,7 @@
     },
     "eslint-utils": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
       "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
@@ -11765,13 +11810,13 @@
     },
     "eslint-visitor-keys": {
       "version": "1.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
     "esm": {
       "version": "3.2.25",
-      "resolved": "https://npm.americanwhitewater.org:443/esm/-/esm-3.2.25.tgz",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
       "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "dev": true
     },
@@ -11796,13 +11841,13 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
       "version": "1.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/esquery/-/esquery-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
       "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
       "dev": true,
       "requires": {
@@ -11836,23 +11881,23 @@
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/estraverse/-/estraverse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "https://npm.americanwhitewater.org:443/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-pubsub": {
       "version": "4.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/event-pubsub/-/event-pubsub-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/event-pubsub/-/event-pubsub-4.3.0.tgz",
       "integrity": "sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==",
       "dev": true
     },
@@ -11870,7 +11915,7 @@
     },
     "eventsource": {
       "version": "1.0.7",
-      "resolved": "https://npm.americanwhitewater.org:443/eventsource/-/eventsource-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
       "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
       "dev": true,
       "requires": {
@@ -11879,7 +11924,7 @@
     },
     "evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
@@ -11889,13 +11934,13 @@
     },
     "exec-sh": {
       "version": "0.3.4",
-      "resolved": "https://npm.americanwhitewater.org:443/exec-sh/-/exec-sh-0.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
       "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
       "dev": true
     },
     "execa": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/execa/-/execa-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
@@ -11910,7 +11955,7 @@
     },
     "execall": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/execall/-/execall-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
       "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
       "dev": true,
       "requires": {
@@ -11919,13 +11964,13 @@
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
@@ -11940,7 +11985,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://npm.americanwhitewater.org:443/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -11949,7 +11994,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -11960,7 +12005,7 @@
     },
     "expect": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/expect/-/expect-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
       "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
       "dev": true,
       "requires": {
@@ -11974,7 +12019,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -11985,7 +12030,7 @@
     },
     "express": {
       "version": "4.17.1",
-      "resolved": "https://npm.americanwhitewater.org:443/express/-/express-4.17.1.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
       "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "requires": {
         "accepts": "~1.3.7",
@@ -12022,13 +12067,13 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -12038,7 +12083,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
@@ -12064,7 +12109,7 @@
     },
     "external-editor": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/external-editor/-/external-editor-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
@@ -12075,7 +12120,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/extglob/-/extglob-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
@@ -12091,7 +12136,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -12100,7 +12145,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -12109,7 +12154,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
@@ -12118,7 +12163,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
@@ -12127,7 +12172,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
@@ -12145,7 +12190,7 @@
     },
     "extract-from-css": {
       "version": "0.4.4",
-      "resolved": "https://npm.americanwhitewater.org:443/extract-from-css/-/extract-from-css-0.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/extract-from-css/-/extract-from-css-0.4.4.tgz",
       "integrity": "sha1-HqffLnx8brmSL6COitrqSG9vj5I=",
       "dev": true,
       "requires": {
@@ -12160,25 +12205,25 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-diff": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/fast-diff/-/fast-diff-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-glob": {
       "version": "2.2.7",
-      "resolved": "https://npm.americanwhitewater.org:443/fast-glob/-/fast-glob-2.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
       "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
       "dev": true,
       "requires": {
@@ -12192,7 +12237,7 @@
       "dependencies": {
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -12202,7 +12247,7 @@
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
-              "resolved": "https://npm.americanwhitewater.org:443/is-glob/-/is-glob-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
@@ -12215,12 +12260,12 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
@@ -12241,7 +12286,7 @@
     },
     "fault": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/fault/-/fault-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
       "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
       "requires": {
         "format": "^0.2.0"
@@ -12249,7 +12294,7 @@
     },
     "faye-websocket": {
       "version": "0.10.0",
-      "resolved": "https://npm.americanwhitewater.org:443/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
@@ -12258,7 +12303,7 @@
     },
     "fb-watchman": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/fb-watchman/-/fb-watchman-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
       "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
       "dev": true,
       "requires": {
@@ -12267,13 +12312,13 @@
     },
     "figgy-pudding": {
       "version": "3.5.2",
-      "resolved": "https://npm.americanwhitewater.org:443/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
     },
     "figures": {
       "version": "3.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/figures/-/figures-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
@@ -12290,7 +12335,7 @@
     },
     "file-entry-cache": {
       "version": "5.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
       "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
@@ -12299,7 +12344,7 @@
     },
     "file-loader": {
       "version": "4.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/file-loader/-/file-loader-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-4.3.0.tgz",
       "integrity": "sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==",
       "dev": true,
       "requires": {
@@ -12309,19 +12354,19 @@
     },
     "file-uri-to-path": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "dev": true
     },
     "filesize": {
       "version": "3.6.1",
-      "resolved": "https://npm.americanwhitewater.org:443/filesize/-/filesize-3.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
       "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
       "dev": true
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
@@ -12333,7 +12378,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -12344,7 +12389,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/finalhandler/-/finalhandler-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "requires": {
         "debug": "2.6.9",
@@ -12358,7 +12403,7 @@
     },
     "find-babel-config": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
       "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
       "dev": true,
       "requires": {
@@ -12368,7 +12413,7 @@
       "dependencies": {
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://npm.americanwhitewater.org:443/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         }
@@ -12376,7 +12421,7 @@
     },
     "find-cache-dir": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
       "dev": true,
       "requires": {
@@ -12441,7 +12486,7 @@
     },
     "find-root": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/find-root/-/find-root-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "dev": true
     },
@@ -12455,7 +12500,7 @@
     },
     "flat-cache": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/flat-cache/-/flat-cache-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
       "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
@@ -12466,7 +12511,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "https://npm.americanwhitewater.org:443/rimraf/-/rimraf-2.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
@@ -12482,19 +12527,19 @@
     },
     "flatted": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/flatted/-/flatted-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
     "flush-promises": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/flush-promises/-/flush-promises-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz",
       "integrity": "sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==",
       "dev": true
     },
     "flush-write-stream": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "dev": true,
       "requires": {
@@ -12504,7 +12549,7 @@
     },
     "follow-redirects": {
       "version": "1.5.10",
-      "resolved": "https://npm.americanwhitewater.org:443/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
         "debug": "=3.1.0"
@@ -12522,19 +12567,19 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://npm.americanwhitewater.org:443/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "https://npm.americanwhitewater.org:443/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
@@ -12545,17 +12590,17 @@
     },
     "format": {
       "version": "0.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/format/-/format-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/forwarded/-/forwarded-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -12564,12 +12609,12 @@
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "https://npm.americanwhitewater.org:443/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "from2": {
       "version": "2.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/from2/-/from2-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
@@ -12579,13 +12624,13 @@
     },
     "fs-capacitor": {
       "version": "2.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/fs-capacitor/-/fs-capacitor-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.4.tgz",
       "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==",
       "dev": true
     },
     "fs-extra": {
       "version": "4.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/fs-extra/-/fs-extra-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
       "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "dev": true,
       "requires": {
@@ -12596,7 +12641,7 @@
     },
     "fs-minipass": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "dev": true,
       "requires": {
@@ -12605,7 +12650,7 @@
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
-      "resolved": "https://npm.americanwhitewater.org:443/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
@@ -12617,20 +12662,20 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fsevents": {
       "version": "2.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/fsevents/-/fsevents-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
     },
     "fstream": {
       "version": "1.0.12",
-      "resolved": "https://npm.americanwhitewater.org:443/fstream/-/fstream-1.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
       "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
@@ -12642,18 +12687,18 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "gauge": {
       "version": "2.7.4",
-      "resolved": "https://npm.americanwhitewater.org:443/gauge/-/gauge-2.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
@@ -12669,13 +12714,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -12684,7 +12729,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -12695,7 +12740,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -12706,7 +12751,7 @@
     },
     "gaze": {
       "version": "1.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/gaze/-/gaze-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
       "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
@@ -12721,7 +12766,7 @@
     },
     "geojson-flatten": {
       "version": "0.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/geojson-flatten/-/geojson-flatten-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-0.2.4.tgz",
       "integrity": "sha512-LiX6Jmot8adiIdZ/fthbcKKPOfWjTQchX/ggHnwMZ2e4b0I243N1ANUos0LvnzepTEsj0+D4fIJ5bKhBrWnAHA==",
       "requires": {
         "get-stdin": "^6.0.0",
@@ -12730,7 +12775,7 @@
     },
     "geojson-rbush": {
       "version": "3.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/geojson-rbush/-/geojson-rbush-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-3.1.2.tgz",
       "integrity": "sha512-grkfdg3HIeTjwTfiJe5FT8+fGU3fABCc+vRJDBwdQz9kkLF0Sbif2gs2JUzjewwgmnvLGy9fInySDeADoNuk7w==",
       "requires": {
         "@turf/bbox": "*",
@@ -12741,12 +12786,12 @@
     },
     "geojson-vt": {
       "version": "3.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/geojson-vt/-/geojson-vt-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
       "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
@@ -12762,18 +12807,18 @@
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
       "dev": true
     },
     "get-stdin": {
       "version": "6.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/get-stdin/-/get-stdin-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
     },
     "get-stream": {
       "version": "4.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/get-stream/-/get-stream-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "requires": {
@@ -12782,13 +12827,13 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://npm.americanwhitewater.org:443/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -12797,7 +12842,7 @@
     },
     "git-parse": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/git-parse/-/git-parse-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/git-parse/-/git-parse-1.0.4.tgz",
       "integrity": "sha512-NSC71SqG6jN0XYPbib8t/mgguVLddw+xvkkLv2EsCFvHfsZjO+ZqMcGoGHHMqfhZllCDDAkOwZESkZEmICj9ZA==",
       "dev": true,
       "requires": {
@@ -12824,7 +12869,7 @@
         },
         "graceful-fs": {
           "version": "4.1.15",
-          "resolved": "https://npm.americanwhitewater.org:443/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
           "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
           "dev": true
         }
@@ -12851,12 +12896,12 @@
     },
     "gl-matrix": {
       "version": "3.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/gl-matrix/-/gl-matrix-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
       "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA=="
     },
     "glob": {
       "version": "7.1.6",
-      "resolved": "https://npm.americanwhitewater.org:443/glob/-/glob-7.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
@@ -12870,7 +12915,7 @@
     },
     "glob-parent": {
       "version": "5.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/glob-parent/-/glob-parent-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
@@ -12879,13 +12924,13 @@
     },
     "glob-to-regexp": {
       "version": "0.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
     },
     "global-dirs": {
       "version": "0.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/global-dirs/-/global-dirs-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
@@ -12894,7 +12939,7 @@
     },
     "global-modules": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/global-modules/-/global-modules-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
       "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
       "dev": true,
       "requires": {
@@ -12903,7 +12948,7 @@
     },
     "global-prefix": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/global-prefix/-/global-prefix-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
       "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
       "dev": true,
       "requires": {
@@ -12914,13 +12959,13 @@
     },
     "globals": {
       "version": "11.12.0",
-      "resolved": "https://npm.americanwhitewater.org:443/globals/-/globals-11.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
     "globby": {
       "version": "9.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/globby/-/globby-9.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
       "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
       "dev": true,
       "requires": {
@@ -12944,13 +12989,13 @@
     },
     "globjoin": {
       "version": "0.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/globjoin/-/globjoin-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
       "dev": true
     },
     "globule": {
       "version": "1.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/globule/-/globule-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
       "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
       "dev": true,
       "requires": {
@@ -12961,7 +13006,7 @@
     },
     "gonzales-pe": {
       "version": "4.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
       "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
       "dev": true,
       "requires": {
@@ -12970,7 +13015,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.5",
-          "resolved": "https://npm.americanwhitewater.org:443/minimist/-/minimist-1.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
@@ -12978,7 +13023,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "https://npm.americanwhitewater.org:443/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -12997,7 +13042,7 @@
       "dependencies": {
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
@@ -13005,7 +13050,7 @@
     },
     "graceful-fs": {
       "version": "4.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "graph-data-structure": {
@@ -13020,7 +13065,7 @@
     },
     "graphql-anywhere": {
       "version": "4.2.7",
-      "resolved": "https://npm.americanwhitewater.org:443/graphql-anywhere/-/graphql-anywhere-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.2.7.tgz",
       "integrity": "sha512-fJHvVywWVWjiHuPIMs16Nfjf4zdQUwSO1LKycwBJCWIPeoeQ8LqXK2BgYoZAHkhKEFktZZeYyzS4o/uIUG0z5A==",
       "dev": true,
       "requires": {
@@ -13031,7 +13076,7 @@
       "dependencies": {
         "ts-invariant": {
           "version": "0.3.3",
-          "resolved": "https://npm.americanwhitewater.org:443/ts-invariant/-/ts-invariant-0.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.3.tgz",
           "integrity": "sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==",
           "dev": true,
           "requires": {
@@ -13053,7 +13098,7 @@
     },
     "graphql-subscriptions": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz",
       "integrity": "sha512-6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==",
       "dev": true,
       "requires": {
@@ -13067,7 +13112,7 @@
     },
     "graphql-tools": {
       "version": "4.0.8",
-      "resolved": "https://npm.americanwhitewater.org:443/graphql-tools/-/graphql-tools-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.8.tgz",
       "integrity": "sha512-MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==",
       "dev": true,
       "requires": {
@@ -13080,7 +13125,7 @@
     },
     "graphql-upload": {
       "version": "8.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/graphql-upload/-/graphql-upload-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",
       "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
       "dev": true,
       "requires": {
@@ -13113,18 +13158,18 @@
     },
     "grid-index": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/grid-index/-/grid-index-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
       "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
     },
     "growly": {
       "version": "1.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/growly/-/growly-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
     "gzip-size": {
       "version": "5.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/gzip-size/-/gzip-size-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
       "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
       "dev": true,
       "requires": {
@@ -13142,13 +13187,13 @@
     },
     "handle-thing": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/handle-thing/-/handle-thing-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
@@ -13164,13 +13209,13 @@
     },
     "hard-rejection": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
       "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
       "dev": true
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/has/-/has-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
         "function-bind": "^1.1.1"
@@ -13178,7 +13223,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -13187,7 +13232,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         }
@@ -13195,28 +13240,28 @@
     },
     "has-color": {
       "version": "0.1.7",
-      "resolved": "https://npm.americanwhitewater.org:443/has-color/-/has-color-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
       "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/has-symbols/-/has-symbols-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/has-unicode/-/has-unicode-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -13235,7 +13280,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -13245,13 +13290,13 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "https://npm.americanwhitewater.org:443/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -13262,7 +13307,7 @@
     },
     "hash-base": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/hash-base/-/hash-base-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "dev": true,
       "requires": {
@@ -13273,7 +13318,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://npm.americanwhitewater.org:443/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
@@ -13284,7 +13329,7 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
         }
@@ -13292,13 +13337,13 @@
     },
     "hash-sum": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/hash-sum/-/hash-sum-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
       "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
       "dev": true
     },
     "hash.js": {
       "version": "1.1.7",
-      "resolved": "https://npm.americanwhitewater.org:443/hash.js/-/hash.js-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "requires": {
@@ -13308,12 +13353,12 @@
     },
     "hat": {
       "version": "0.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/hat/-/hat-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
       "integrity": "sha1-uwFKnmSzeIrtgAWRdBPU/z1QLYo="
     },
     "he": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/he/-/he-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
@@ -13329,7 +13374,7 @@
     },
     "hex-color-regex": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
     },
@@ -13340,7 +13385,7 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
@@ -13359,18 +13404,18 @@
     },
     "hoopy": {
       "version": "0.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/hoopy/-/hoopy-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
       "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
       "dev": true
     },
     "hosted-git-info": {
       "version": "2.8.8",
-      "resolved": "https://npm.americanwhitewater.org:443/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "https://npm.americanwhitewater.org:443/hpack.js/-/hpack.js-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
@@ -13382,25 +13427,25 @@
     },
     "hsl-regex": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/hsl-regex/-/hsl-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
       "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
       "dev": true
     },
     "hsla-regex": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/hsla-regex/-/hsla-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
       "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
       "dev": true
     },
     "html-comment-regex": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
       "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
@@ -13409,19 +13454,19 @@
     },
     "html-entities": {
       "version": "1.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/html-entities/-/html-entities-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
       "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
       "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/html-escaper/-/html-escaper-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
     "html-minifier": {
       "version": "3.5.21",
-      "resolved": "https://npm.americanwhitewater.org:443/html-minifier/-/html-minifier-3.5.21.tgz",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
       "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
       "dev": true,
       "requires": {
@@ -13436,7 +13481,7 @@
       "dependencies": {
         "commander": {
           "version": "2.17.1",
-          "resolved": "https://npm.americanwhitewater.org:443/commander/-/commander-2.17.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
           "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
           "dev": true
         }
@@ -13450,7 +13495,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -13465,25 +13510,25 @@
       "dependencies": {
         "big.js": {
           "version": "3.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/big.js/-/big.js-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
           "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
           "dev": true
         },
         "emojis-list": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/emojis-list/-/emojis-list-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
           "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
           "dev": true
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://npm.americanwhitewater.org:443/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },
         "loader-utils": {
           "version": "0.2.17",
-          "resolved": "https://npm.americanwhitewater.org:443/loader-utils/-/loader-utils-0.2.17.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
@@ -13495,7 +13540,7 @@
         },
         "util.promisify": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/util.promisify/-/util.promisify-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
           "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
           "dev": true,
           "requires": {
@@ -13507,7 +13552,7 @@
     },
     "htmlparser2": {
       "version": "4.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/htmlparser2/-/htmlparser2-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
       "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
       "requires": {
         "domelementtype": "^2.0.1",
@@ -13518,7 +13563,7 @@
     },
     "http-call": {
       "version": "5.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/http-call/-/http-call-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-call/-/http-call-5.3.0.tgz",
       "integrity": "sha512-ahwimsC23ICE4kPl9xTBjKB4inbRaeLyZeRunC/1Jy/Z6X8tv22MEAjK+KBOMSVLaqXPTTmd8638waVIKLGx2w==",
       "dev": true,
       "requires": {
@@ -13541,19 +13586,19 @@
         },
         "is-stream": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-stream/-/is-stream-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -13565,13 +13610,13 @@
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "https://npm.americanwhitewater.org:443/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
     "http-errors": {
       "version": "1.7.2",
-      "resolved": "https://npm.americanwhitewater.org:443/http-errors/-/http-errors-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "requires": {
         "depd": "~1.1.2",
@@ -13583,14 +13628,14 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
     "http-proxy": {
       "version": "1.18.1",
-      "resolved": "https://npm.americanwhitewater.org:443/http-proxy/-/http-proxy-1.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
       "requires": {
@@ -13601,7 +13646,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.19.1",
-      "resolved": "https://npm.americanwhitewater.org:443/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
       "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
       "dev": true,
       "requires": {
@@ -13613,7 +13658,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -13624,25 +13669,25 @@
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/https-browserify/-/https-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
     "human-signals": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/human-signals/-/human-signals-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
     },
     "hyperlinker": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/hyperlinker/-/hyperlinker-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
       "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
       "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://npm.americanwhitewater.org:443/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -13650,7 +13695,7 @@
     },
     "icss-utils": {
       "version": "4.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/icss-utils/-/icss-utils-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
       "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "dev": true,
       "requires": {
@@ -13723,19 +13768,19 @@
     },
     "iferr": {
       "version": "0.1.5",
-      "resolved": "https://npm.americanwhitewater.org:443/iferr/-/iferr-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
     "ignore": {
       "version": "4.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/ignore/-/ignore-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
     "ignore-by-default": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
@@ -13747,7 +13792,7 @@
     },
     "import-cwd": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/import-cwd/-/import-cwd-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "dev": true,
       "requires": {
@@ -13756,7 +13801,7 @@
     },
     "import-fresh": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/import-fresh/-/import-fresh-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "requires": {
@@ -13766,7 +13811,7 @@
     },
     "import-from": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/import-from/-/import-from-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "requires": {
@@ -13775,13 +13820,13 @@
     },
     "import-lazy": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/import-lazy/-/import-lazy-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
       "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
       "dev": true
     },
     "import-local": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/import-local/-/import-local-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
       "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
       "dev": true,
       "requires": {
@@ -13845,31 +13890,31 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "in-publish": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/in-publish/-/in-publish-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
       "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
       "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/indent-string/-/indent-string-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "indexes-of": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/indexes-of/-/indexes-of-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
     "infer-owner": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/infer-owner/-/infer-owner-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "dev": true
     },
@@ -13881,7 +13926,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -13891,12 +13936,12 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "https://npm.americanwhitewater.org:443/ini/-/ini-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
@@ -13923,7 +13968,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
@@ -13948,7 +13993,7 @@
         },
         "cli-cursor": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
           "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
           "dev": true,
           "requires": {
@@ -13957,7 +14002,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -13966,19 +14011,19 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
           "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
@@ -13993,7 +14038,7 @@
         },
         "restore-cursor": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
           "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
           "dev": true,
           "requires": {
@@ -14003,7 +14048,7 @@
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
@@ -14014,7 +14059,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -14034,7 +14079,7 @@
     },
     "internal-ip": {
       "version": "4.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/internal-ip/-/internal-ip-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
       "integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
       "dev": true,
       "requires": {
@@ -14044,7 +14089,7 @@
       "dependencies": {
         "default-gateway": {
           "version": "4.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/default-gateway/-/default-gateway-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
           "integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
           "dev": true,
           "requires": {
@@ -14056,13 +14101,13 @@
     },
     "interpret": {
       "version": "1.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/interpret/-/interpret-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/invariant/-/invariant-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
@@ -14071,30 +14116,30 @@
     },
     "ip": {
       "version": "1.1.5",
-      "resolved": "https://npm.americanwhitewater.org:443/ip/-/ip-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/ip-regex/-/ip-regex-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true
     },
     "ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://npm.americanwhitewater.org:443/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-absolute-url": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
       "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://npm.americanwhitewater.org:443/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -14103,13 +14148,13 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "https://npm.americanwhitewater.org:443/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.americanwhitewater.org:443/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -14120,19 +14165,19 @@
     },
     "is-alphabetical": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
       "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
       "dev": true
     },
     "is-alphanumeric": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
       "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
       "dev": true
     },
     "is-alphanumerical": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
       "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
       "dev": true,
       "requires": {
@@ -14142,18 +14187,18 @@
     },
     "is-arguments": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/is-arguments/-/is-arguments-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
       "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
       "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "optional": true,
@@ -14173,7 +14218,7 @@
     },
     "is-ci": {
       "version": "1.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/is-ci/-/is-ci-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
       "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "dev": true,
       "requires": {
@@ -14182,7 +14227,7 @@
     },
     "is-color-stop": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-color-stop/-/is-color-stop-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "dev": true,
       "requires": {
@@ -14204,7 +14249,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -14213,13 +14258,13 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "https://npm.americanwhitewater.org:443/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.americanwhitewater.org:443/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -14230,18 +14275,18 @@
     },
     "is-date-object": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/is-date-object/-/is-date-object-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-decimal": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/is-decimal/-/is-decimal-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
       "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
       "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://npm.americanwhitewater.org:443/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
@@ -14252,7 +14297,7 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/kind-of/-/kind-of-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
@@ -14260,7 +14305,7 @@
     },
     "is-directory": {
       "version": "0.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/is-directory/-/is-directory-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
@@ -14272,36 +14317,36 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-finite": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-finite/-/is-finite-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
       "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-generator-fn": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
     "is-glob": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/is-glob/-/is-glob-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
@@ -14310,13 +14355,13 @@
     },
     "is-hexadecimal": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
       "dev": true
     },
     "is-installed-globally": {
       "version": "0.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
@@ -14326,7 +14371,7 @@
       "dependencies": {
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "dev": true,
           "requires": {
@@ -14342,13 +14387,13 @@
     },
     "is-npm": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-npm/-/is-npm-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
       "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "dev": true
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
@@ -14357,13 +14402,13 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "https://npm.americanwhitewater.org:443/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.americanwhitewater.org:443/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -14374,13 +14419,13 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
     "is-observable": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-observable/-/is-observable-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
       "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
       "dev": true,
       "requires": {
@@ -14397,13 +14442,13 @@
     },
     "is-path-cwd": {
       "version": "2.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
       "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
       "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
       "dev": true,
       "requires": {
@@ -14412,7 +14457,7 @@
     },
     "is-path-inside": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-path-inside/-/is-path-inside-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
       "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
       "dev": true,
       "requires": {
@@ -14421,7 +14466,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
@@ -14432,13 +14477,13 @@
     },
     "is-promise": {
       "version": "2.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/is-promise/-/is-promise-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-redirect/-/is-redirect-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
@@ -14452,19 +14497,19 @@
     },
     "is-regexp": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-regexp/-/is-regexp-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-resolvable": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-retry-allowed": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
       "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true
     },
@@ -14479,18 +14524,18 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-string": {
       "version": "1.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/is-string/-/is-string-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
       "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
     },
     "is-svg": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-svg/-/is-svg-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
       "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
       "dev": true,
       "requires": {
@@ -14499,7 +14544,7 @@
     },
     "is-symbol": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/is-symbol/-/is-symbol-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
         "has-symbols": "^1.0.1"
@@ -14507,54 +14552,54 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "is-whitespace": {
       "version": "0.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-whitespace/-/is-whitespace-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
       "integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38=",
       "dev": true
     },
     "is-whitespace-character": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
       "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
       "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "is-word-character": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/is-word-character/-/is-word-character-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
       "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
       "dev": true
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -14568,19 +14613,19 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
       "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
       "dev": true
     },
     "istanbul-lib-instrument": {
       "version": "3.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
       "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
       "dev": true,
       "requires": {
@@ -14595,7 +14640,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -14603,7 +14648,7 @@
     },
     "istanbul-lib-report": {
       "version": "2.0.8",
-      "resolved": "https://npm.americanwhitewater.org:443/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
       "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
       "dev": true,
       "requires": {
@@ -14614,7 +14659,7 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/supports-color/-/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
@@ -14625,7 +14670,7 @@
     },
     "istanbul-lib-source-maps": {
       "version": "3.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
       "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
       "dev": true,
       "requires": {
@@ -14647,7 +14692,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -14655,7 +14700,7 @@
     },
     "istanbul-reports": {
       "version": "2.2.7",
-      "resolved": "https://npm.americanwhitewater.org:443/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
       "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
       "dev": true,
       "requires": {
@@ -14664,25 +14709,25 @@
     },
     "iterall": {
       "version": "1.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/iterall/-/iterall-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
       "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
       "dev": true
     },
     "java-properties": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/java-properties/-/java-properties-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
       "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
       "dev": true
     },
     "javascript-stringify": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/javascript-stringify/-/javascript-stringify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.0.1.tgz",
       "integrity": "sha512-yV+gqbd5vaOYjqlbk16EG89xB5udgjqQF3C5FAORDg4f/IS1Yc5ERCv5e/57yBcfJYw05V5JyIXabhwb75Xxow==",
       "dev": true
     },
     "jest": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest/-/jest-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
       "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
       "dev": true,
       "requires": {
@@ -14692,7 +14737,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -14701,7 +14746,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -14712,7 +14757,7 @@
         },
         "ci-info": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ci-info/-/ci-info-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
           "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "dev": true
         },
@@ -14724,7 +14769,7 @@
         },
         "is-ci": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-ci/-/is-ci-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
           "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
           "dev": true,
           "requires": {
@@ -14733,7 +14778,7 @@
         },
         "jest-cli": {
           "version": "24.9.0",
-          "resolved": "https://npm.americanwhitewater.org:443/jest-cli/-/jest-cli-24.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
           "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
           "dev": true,
           "requires": {
@@ -14756,7 +14801,7 @@
     },
     "jest-changed-files": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
       "integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
       "dev": true,
       "requires": {
@@ -14767,7 +14812,7 @@
     },
     "jest-config": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-config/-/jest-config-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
       "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
       "dev": true,
       "requires": {
@@ -14792,7 +14837,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -14801,7 +14846,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -14820,7 +14865,7 @@
     },
     "jest-diff": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-diff/-/jest-diff-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
       "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
       "dev": true,
       "requires": {
@@ -14832,7 +14877,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -14841,7 +14886,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -14860,7 +14905,7 @@
     },
     "jest-docblock": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-docblock/-/jest-docblock-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
       "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
       "dev": true,
       "requires": {
@@ -14869,7 +14914,7 @@
     },
     "jest-each": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-each/-/jest-each-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
       "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
       "dev": true,
       "requires": {
@@ -14882,7 +14927,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -14891,7 +14936,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -14910,7 +14955,7 @@
     },
     "jest-environment-jsdom": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
       "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
       "dev": true,
       "requires": {
@@ -14924,7 +14969,7 @@
     },
     "jest-environment-jsdom-fifteen": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-environment-jsdom-fifteen/-/jest-environment-jsdom-fifteen-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom-fifteen/-/jest-environment-jsdom-fifteen-1.0.2.tgz",
       "integrity": "sha512-nfrnAfwklE1872LIB31HcjM65cWTh1wzvMSp10IYtPJjLDUbTTvDpajZgIxUnhRmzGvogdHDayCIlerLK0OBBg==",
       "dev": true,
       "requires": {
@@ -14944,13 +14989,13 @@
         },
         "cssom": {
           "version": "0.4.4",
-          "resolved": "https://npm.americanwhitewater.org:443/cssom/-/cssom-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
           "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
           "dev": true
         },
         "cssstyle": {
           "version": "2.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/cssstyle/-/cssstyle-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
           "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
           "dev": true,
           "requires": {
@@ -14959,7 +15004,7 @@
           "dependencies": {
             "cssom": {
               "version": "0.3.8",
-              "resolved": "https://npm.americanwhitewater.org:443/cssom/-/cssom-0.3.8.tgz",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
               "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
               "dev": true
             }
@@ -14967,7 +15012,7 @@
         },
         "jsdom": {
           "version": "15.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/jsdom/-/jsdom-15.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
           "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
           "dev": true,
           "requires": {
@@ -15001,13 +15046,13 @@
         },
         "parse5": {
           "version": "5.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/parse5/-/parse5-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
           "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
           "dev": true
         },
         "tough-cookie": {
           "version": "3.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
           "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
           "dev": true,
           "requires": {
@@ -15018,7 +15063,7 @@
         },
         "whatwg-url": {
           "version": "7.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
           "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
           "dev": true,
           "requires": {
@@ -15037,7 +15082,7 @@
     },
     "jest-environment-node": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
       "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
       "dev": true,
       "requires": {
@@ -15050,13 +15095,13 @@
     },
     "jest-get-type": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-get-type/-/jest-get-type-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
       "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
       "dev": true
     },
     "jest-haste-map": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
       "integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
       "dev": true,
       "requires": {
@@ -15076,7 +15121,7 @@
       "dependencies": {
         "anymatch": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/anymatch/-/anymatch-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
@@ -15086,7 +15131,7 @@
         },
         "fsevents": {
           "version": "1.2.13",
-          "resolved": "https://npm.americanwhitewater.org:443/fsevents/-/fsevents-1.2.13.tgz",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
           "optional": true,
@@ -15097,7 +15142,7 @@
         },
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/normalize-path/-/normalize-path-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
@@ -15108,7 +15153,7 @@
     },
     "jest-jasmine2": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
       "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
       "dev": true,
       "requires": {
@@ -15132,7 +15177,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -15141,7 +15186,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -15160,7 +15205,7 @@
     },
     "jest-leak-detector": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
       "integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
       "dev": true,
       "requires": {
@@ -15170,7 +15215,7 @@
     },
     "jest-matcher-utils": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
       "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
       "dev": true,
       "requires": {
@@ -15182,7 +15227,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -15191,7 +15236,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -15210,7 +15255,7 @@
     },
     "jest-message-util": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-message-util/-/jest-message-util-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
       "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
       "dev": true,
       "requires": {
@@ -15226,7 +15271,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -15235,7 +15280,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -15254,7 +15299,7 @@
     },
     "jest-mock": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-mock/-/jest-mock-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
       "integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
       "dev": true,
       "requires": {
@@ -15263,19 +15308,19 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
       "dev": true
     },
     "jest-regex-util": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
       "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
       "dev": true
     },
     "jest-resolve": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-resolve/-/jest-resolve-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
       "integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
       "dev": true,
       "requires": {
@@ -15288,7 +15333,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -15297,7 +15342,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -15316,7 +15361,7 @@
     },
     "jest-resolve-dependencies": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
       "integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
       "dev": true,
       "requires": {
@@ -15327,7 +15372,7 @@
     },
     "jest-runner": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-runner/-/jest-runner-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
       "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
       "dev": true,
       "requires": {
@@ -15354,7 +15399,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -15363,7 +15408,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -15382,7 +15427,7 @@
     },
     "jest-runtime": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-runtime/-/jest-runtime-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
       "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
       "dev": true,
       "requires": {
@@ -15413,7 +15458,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -15422,7 +15467,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -15441,13 +15486,13 @@
     },
     "jest-serializer": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-serializer/-/jest-serializer-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
       "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
       "dev": true
     },
     "jest-serializer-vue": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-serializer-vue/-/jest-serializer-vue-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/jest-serializer-vue/-/jest-serializer-vue-2.0.2.tgz",
       "integrity": "sha1-sjjvKGNX7GtIBCG9RxRQUJh9WbM=",
       "dev": true,
       "requires": {
@@ -15456,7 +15501,7 @@
     },
     "jest-snapshot": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
       "integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
       "dev": true,
       "requires": {
@@ -15477,7 +15522,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -15486,7 +15531,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -15503,7 +15548,7 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -15516,13 +15561,13 @@
     },
     "jest-transform-stub": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-transform-stub/-/jest-transform-stub-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-transform-stub/-/jest-transform-stub-2.0.0.tgz",
       "integrity": "sha512-lspHaCRx/mBbnm3h4uMMS3R5aZzMwyNpNIJLXj4cEsV0mIUtS4IjYJLSoyjRCtnxb6RIGJ4NL2quZzfIeNhbkg==",
       "dev": true
     },
     "jest-util": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-util/-/jest-util-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
       "integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
       "dev": true,
       "requires": {
@@ -15542,7 +15587,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -15551,7 +15596,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -15562,7 +15607,7 @@
         },
         "ci-info": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ci-info/-/ci-info-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
           "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "dev": true
         },
@@ -15574,7 +15619,7 @@
         },
         "is-ci": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-ci/-/is-ci-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
           "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
           "dev": true,
           "requires": {
@@ -15585,7 +15630,7 @@
     },
     "jest-validate": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-validate/-/jest-validate-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
       "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
       "dev": true,
       "requires": {
@@ -15599,7 +15644,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -15614,7 +15659,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -15633,7 +15678,7 @@
     },
     "jest-watch-typeahead": {
       "version": "0.4.2",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-watch-typeahead/-/jest-watch-typeahead-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-0.4.2.tgz",
       "integrity": "sha512-f7VpLebTdaXs81rg/oj4Vg/ObZy2QtGzAmGLNsqUS5G5KtSN68tFcIsbvNODfNyQxU78g7D8x77o3bgfBTR+2Q==",
       "dev": true,
       "requires": {
@@ -15648,13 +15693,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -15663,7 +15708,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -15680,13 +15725,13 @@
         },
         "slash": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/slash/-/slash-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
         },
         "string-length": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-length/-/string-length-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
           "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
           "dev": true,
           "requires": {
@@ -15696,7 +15741,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -15707,7 +15752,7 @@
     },
     "jest-watcher": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-watcher/-/jest-watcher-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
       "integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
       "dev": true,
       "requires": {
@@ -15722,13 +15767,13 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -15737,7 +15782,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -15756,7 +15801,7 @@
     },
     "jest-worker": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jest-worker/-/jest-worker-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
       "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
       "dev": true,
       "requires": {
@@ -15766,7 +15811,7 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/supports-color/-/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
@@ -15796,7 +15841,7 @@
       "dependencies": {
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": "https://npm.americanwhitewater.org:443/mkdirp/-/mkdirp-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         }
@@ -15804,13 +15849,13 @@
     },
     "js-message": {
       "version": "1.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/js-message/-/js-message-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz",
       "integrity": "sha1-IwDSSxrwjondCVvBpMnJz8uJLRU=",
       "dev": true
     },
     "js-queue": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/js-queue/-/js-queue-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.0.tgz",
       "integrity": "sha1-NiITz4YPRo8BJfxslqvBdCUx+Ug=",
       "dev": true,
       "requires": {
@@ -15819,12 +15864,12 @@
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.0",
-      "resolved": "https://npm.americanwhitewater.org:443/js-yaml/-/js-yaml-3.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
       "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
@@ -15834,13 +15879,13 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
     "jsdom": {
       "version": "11.12.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jsdom/-/jsdom-11.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
       "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
       "dev": true,
       "requires": {
@@ -15874,7 +15919,7 @@
       "dependencies": {
         "acorn": {
           "version": "5.7.4",
-          "resolved": "https://npm.americanwhitewater.org:443/acorn/-/acorn-5.7.4.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
           "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         }
@@ -15882,13 +15927,13 @@
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "https://npm.americanwhitewater.org:443/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
@@ -15900,19 +15945,19 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://npm.americanwhitewater.org:443/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://npm.americanwhitewater.org:443/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
@@ -15921,19 +15966,19 @@
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json3": {
       "version": "3.3.3",
-      "resolved": "https://npm.americanwhitewater.org:443/json3/-/json3-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
       "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
       "dev": true
     },
@@ -15947,7 +15992,7 @@
     },
     "jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
@@ -15956,13 +16001,13 @@
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/jsonify/-/jsonify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsonlint-lines": {
       "version": "1.7.1",
-      "resolved": "https://npm.americanwhitewater.org:443/jsonlint-lines/-/jsonlint-lines-1.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonlint-lines/-/jsonlint-lines-1.7.1.tgz",
       "integrity": "sha1-UH3mgNP7jEvhZBzFfW9nnynxeP8=",
       "requires": {
         "JSV": ">= 4.0.x",
@@ -15971,7 +16016,7 @@
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://npm.americanwhitewater.org:443/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -15983,24 +16028,24 @@
     },
     "kdbush": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/kdbush/-/kdbush-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
       "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
     "killable": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/killable/-/killable-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
       "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==",
       "dev": true
     },
     "kind-of": {
       "version": "6.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/kind-of/-/kind-of-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "kleur": {
       "version": "3.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/kleur/-/kleur-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
@@ -16011,13 +16056,13 @@
     },
     "known-css-properties": {
       "version": "0.19.0",
-      "resolved": "https://npm.americanwhitewater.org:443/known-css-properties/-/known-css-properties-0.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.19.0.tgz",
       "integrity": "sha512-eYboRV94Vco725nKMlpkn3nV2+96p9c3gKXRsYqAJSswSENvBhN7n5L+uDhY58xQa0UukWsDMTGELzmD8Q+wTA==",
       "dev": true
     },
     "latest-version": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/latest-version/-/latest-version-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
@@ -16026,7 +16071,7 @@
     },
     "launch-editor": {
       "version": "2.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/launch-editor/-/launch-editor-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.2.1.tgz",
       "integrity": "sha512-On+V7K2uZK6wK7x691ycSUbLD/FyKKelArkbaAMSSJU8JmqmhwN2+mnJDNINuJWSrh2L0kDk+ZQtbC/gOWUwLw==",
       "dev": true,
       "requires": {
@@ -16036,7 +16081,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -16045,7 +16090,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -16064,7 +16109,7 @@
     },
     "launch-editor-middleware": {
       "version": "2.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/launch-editor-middleware/-/launch-editor-middleware-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/launch-editor-middleware/-/launch-editor-middleware-2.2.1.tgz",
       "integrity": "sha512-s0UO2/gEGiCgei3/2UN3SMuUj1phjQN8lcpnvgLSz26fAzNWPQ6Nf/kF5IFClnfU2ehp6LrmKdMU/beveO+2jg==",
       "dev": true,
       "requires": {
@@ -16073,25 +16118,25 @@
     },
     "lcov-parse": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
       "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
       "dev": true
     },
     "left-pad": {
       "version": "1.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/left-pad/-/left-pad-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
       "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
       "dev": true
     },
     "leven": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/leven/-/leven-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -16119,7 +16164,7 @@
     },
     "lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "https://npm.americanwhitewater.org:443/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
@@ -16157,7 +16202,7 @@
         },
         "braces": {
           "version": "3.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/braces/-/braces-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
           "requires": {
@@ -16166,7 +16211,7 @@
         },
         "chalk": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
@@ -16176,7 +16221,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -16204,7 +16249,7 @@
         },
         "cross-spawn": {
           "version": "7.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
           "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
@@ -16241,7 +16286,7 @@
         },
         "fill-range": {
           "version": "7.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/fill-range/-/fill-range-7.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
@@ -16259,7 +16304,7 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
@@ -16275,19 +16320,19 @@
         },
         "is-number": {
           "version": "7.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-number/-/is-number-7.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
         "is-stream": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-stream/-/is-stream-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
         },
         "log-symbols": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/log-symbols/-/log-symbols-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
           "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
           "dev": true,
           "requires": {
@@ -16296,7 +16341,7 @@
         },
         "micromatch": {
           "version": "4.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/micromatch/-/micromatch-4.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
           "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
           "dev": true,
           "requires": {
@@ -16306,19 +16351,19 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
           "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "npm-run-path": {
           "version": "4.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
           "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
           "dev": true,
           "requires": {
@@ -16348,25 +16393,25 @@
         },
         "path-key": {
           "version": "3.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/path-key/-/path-key-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
         "path-type": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/path-type/-/path-type-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/resolve-from/-/resolve-from-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
         "shebang-command": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/shebang-command/-/shebang-command-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
@@ -16375,7 +16420,7 @@
         },
         "shebang-regex": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
@@ -16390,7 +16435,7 @@
         },
         "to-regex-range": {
           "version": "5.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
@@ -16399,7 +16444,7 @@
         },
         "which": {
           "version": "2.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/which/-/which-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
@@ -16410,7 +16455,7 @@
     },
     "listr": {
       "version": "0.14.3",
-      "resolved": "https://npm.americanwhitewater.org:443/listr/-/listr-0.14.3.tgz",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
       "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
       "dev": true,
       "requires": {
@@ -16427,7 +16472,7 @@
       "dependencies": {
         "p-map": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/p-map/-/p-map-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
           "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
           "dev": true
         }
@@ -16435,13 +16480,13 @@
     },
     "listr-silent-renderer": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
       "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
       "dev": true
     },
     "listr-update-renderer": {
       "version": "0.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
       "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
       "dev": true,
       "requires": {
@@ -16457,25 +16502,25 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -16488,7 +16533,7 @@
         },
         "cli-truncate": {
           "version": "0.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/cli-truncate/-/cli-truncate-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
           "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
           "dev": true,
           "requires": {
@@ -16504,7 +16549,7 @@
         },
         "figures": {
           "version": "1.7.0",
-          "resolved": "https://npm.americanwhitewater.org:443/figures/-/figures-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
@@ -16514,13 +16559,13 @@
         },
         "indent-string": {
           "version": "3.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/indent-string/-/indent-string-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -16529,7 +16574,7 @@
         },
         "log-symbols": {
           "version": "1.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/log-symbols/-/log-symbols-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
@@ -16538,7 +16583,7 @@
         },
         "log-update": {
           "version": "2.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/log-update/-/log-update-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
           "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
           "dev": true,
           "requires": {
@@ -16549,13 +16594,13 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "https://npm.americanwhitewater.org:443/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -16566,7 +16611,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -16575,13 +16620,13 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "3.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
           "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
           "dev": true,
           "requires": {
@@ -16591,19 +16636,19 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://npm.americanwhitewater.org:443/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "string-width": {
               "version": "2.1.1",
-              "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
@@ -16613,7 +16658,7 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
@@ -16626,7 +16671,7 @@
     },
     "listr-verbose-renderer": {
       "version": "0.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
       "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
       "dev": true,
       "requires": {
@@ -16638,7 +16683,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -16647,7 +16692,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -16664,7 +16709,7 @@
         },
         "figures": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/figures/-/figures-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
@@ -16700,7 +16745,7 @@
         },
         "chalk": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
@@ -16710,7 +16755,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -16719,13 +16764,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "p-map": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/p-map/-/p-map-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
           "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
           "dev": true,
           "requires": {
@@ -16756,7 +16801,7 @@
     },
     "loader-fs-cache": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/loader-fs-cache/-/loader-fs-cache-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.3.tgz",
       "integrity": "sha512-ldcgZpjNJj71n+2Mf6yetz+c9bM4xpKtNds4LbqXzU/PTdeAX0g3ytnU1AJMEcTk2Lex4Smpe3Q/eCTsvUBxbA==",
       "dev": true,
       "requires": {
@@ -16766,7 +16811,7 @@
       "dependencies": {
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
@@ -16777,7 +16822,7 @@
         },
         "find-up": {
           "version": "1.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/find-up/-/find-up-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
@@ -16787,7 +16832,7 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/path-exists/-/path-exists-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
@@ -16796,7 +16841,7 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
@@ -16807,13 +16852,13 @@
     },
     "loader-runner": {
       "version": "2.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/loader-runner/-/loader-runner-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
       "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
       "dev": true
     },
     "loader-utils": {
       "version": "1.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/loader-utils/-/loader-utils-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
       "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
       "dev": true,
       "requires": {
@@ -16847,77 +16892,77 @@
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
     "lodash.debounce": {
       "version": "4.0.8",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.defaultsdeep": {
       "version": "4.6.1",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.identity": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.identity/-/lodash.identity-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
       "integrity": "sha1-rXvGpOZH15yXLhuA/u968VYmeHY=",
       "dev": true
     },
     "lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
       "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
       "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
       "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.pickby": {
       "version": "4.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
       "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
       "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "lodash.template": {
       "version": "4.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.template/-/lodash.template-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
       "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
       "dev": true,
       "requires": {
@@ -16927,7 +16972,7 @@
     },
     "lodash.templatesettings": {
       "version": "4.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
       "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
       "dev": true,
       "requires": {
@@ -16936,31 +16981,31 @@
     },
     "lodash.transform": {
       "version": "4.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.transform/-/lodash.transform-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
       "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
       "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
     "lodash.xorby": {
       "version": "4.7.0",
-      "resolved": "https://npm.americanwhitewater.org:443/lodash.xorby/-/lodash.xorby-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.xorby/-/lodash.xorby-4.7.0.tgz",
       "integrity": "sha1-nBmm+fBjputT3QPBtocXmYAUY9c=",
       "dev": true
     },
     "log-driver": {
       "version": "1.2.7",
-      "resolved": "https://npm.americanwhitewater.org:443/log-driver/-/log-driver-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/log-symbols/-/log-symbols-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
@@ -16969,7 +17014,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -16978,7 +17023,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -16997,7 +17042,7 @@
     },
     "log-update": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/log-update/-/log-update-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
       "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
       "dev": true,
       "requires": {
@@ -17009,7 +17054,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
@@ -17024,13 +17069,13 @@
         },
         "astral-regex": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/astral-regex/-/astral-regex-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
           "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
           "dev": true
         },
         "cli-cursor": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
           "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
           "dev": true,
           "requires": {
@@ -17039,7 +17084,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -17048,13 +17093,13 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
           "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
@@ -17069,7 +17114,7 @@
         },
         "restore-cursor": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
           "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
           "dev": true,
           "requires": {
@@ -17079,7 +17124,7 @@
         },
         "slice-ansi": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
           "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
           "dev": true,
           "requires": {
@@ -17090,7 +17135,7 @@
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
@@ -17101,7 +17146,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -17110,7 +17155,7 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
           "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "requires": {
@@ -17129,19 +17174,19 @@
     },
     "long": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/long/-/long-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
       "dev": true
     },
     "longest-streak": {
       "version": "2.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/longest-streak/-/longest-streak-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
       "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
       "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -17149,7 +17194,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -17159,13 +17204,13 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
@@ -17180,7 +17225,7 @@
     },
     "lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
@@ -17189,7 +17234,7 @@
     },
     "make-dir": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/make-dir/-/make-dir-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
       "requires": {
@@ -17207,13 +17252,13 @@
     },
     "make-error": {
       "version": "1.3.6",
-      "resolved": "https://npm.americanwhitewater.org:443/make-error/-/make-error-1.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "makeerror": {
       "version": "1.0.11",
-      "resolved": "https://npm.americanwhitewater.org:443/makeerror/-/makeerror-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
@@ -17222,19 +17267,19 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-obj": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/map-obj/-/map-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -17273,30 +17318,30 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.5",
-          "resolved": "https://npm.americanwhitewater.org:443/minimist/-/minimist-1.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "quickselect": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/quickselect/-/quickselect-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
           "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
         },
         "rw": {
           "version": "1.3.3",
-          "resolved": "https://npm.americanwhitewater.org:443/rw/-/rw-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
           "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
         }
       }
     },
     "markdown-escapes": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
       "dev": true
     },
     "markdown-table": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/markdown-table/-/markdown-table-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
       "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
       "dev": true,
       "requires": {
@@ -17305,13 +17350,13 @@
     },
     "mathml-tag-names": {
       "version": "2.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
       "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
-      "resolved": "https://npm.americanwhitewater.org:443/md5.js/-/md5.js-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
@@ -17322,7 +17367,7 @@
     },
     "mdast-util-compact": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz",
       "integrity": "sha512-7GlnT24gEwDrdAwEHrU4Vv5lLWrEer4KOkAiKT9nYstsTad7Oc1TwqT2zIMKRdZF7cTuaf+GA1E4Kv7jJh8mPA==",
       "dev": true,
       "requires": {
@@ -17331,18 +17376,18 @@
     },
     "mdn-data": {
       "version": "2.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/mdn-data/-/mdn-data-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
       "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "memory-fs": {
       "version": "0.4.1",
-      "resolved": "https://npm.americanwhitewater.org:443/memory-fs/-/memory-fs-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
@@ -17352,7 +17397,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://npm.americanwhitewater.org:443/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -17370,7 +17415,7 @@
       "dependencies": {
         "find-up": {
           "version": "1.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/find-up/-/find-up-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
@@ -17380,7 +17425,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -17393,7 +17438,7 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/path-exists/-/path-exists-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
@@ -17402,7 +17447,7 @@
         },
         "path-type": {
           "version": "1.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/path-type/-/path-type-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
@@ -17413,7 +17458,7 @@
         },
         "read-pkg": {
           "version": "1.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/read-pkg/-/read-pkg-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
@@ -17424,7 +17469,7 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
@@ -17434,7 +17479,7 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
@@ -17445,12 +17490,12 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-source-map": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
       "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
       "dev": true,
       "requires": {
@@ -17459,24 +17504,24 @@
     },
     "merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/merge-stream/-/merge-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
     "merge2": {
       "version": "1.4.1",
-      "resolved": "https://npm.americanwhitewater.org:443/merge2/-/merge2-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
       "version": "3.1.10",
-      "resolved": "https://npm.americanwhitewater.org:443/micromatch/-/micromatch-3.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
@@ -17497,7 +17542,7 @@
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
@@ -17507,7 +17552,7 @@
       "dependencies": {
         "bn.js": {
           "version": "4.11.9",
-          "resolved": "https://npm.americanwhitewater.org:443/bn.js/-/bn.js-4.11.9.tgz",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
@@ -17515,17 +17560,17 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/mime/-/mime-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.44.0",
-      "resolved": "https://npm.americanwhitewater.org:443/mime-db/-/mime-db-1.44.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
       "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
       "version": "2.1.27",
-      "resolved": "https://npm.americanwhitewater.org:443/mime-types/-/mime-types-2.1.27.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "requires": {
         "mime-db": "1.44.0"
@@ -17533,19 +17578,19 @@
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "min-indent": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/min-indent/-/min-indent-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
     "mini-css-extract-plugin": {
       "version": "0.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
       "integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
       "dev": true,
       "requires": {
@@ -17557,7 +17602,7 @@
       "dependencies": {
         "normalize-url": {
           "version": "1.9.1",
-          "resolved": "https://npm.americanwhitewater.org:443/normalize-url/-/normalize-url-1.9.1.tgz",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
           "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
           "dev": true,
           "requires": {
@@ -17569,7 +17614,7 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/schema-utils/-/schema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
@@ -17582,19 +17627,19 @@
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -17602,12 +17647,12 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimist-options": {
       "version": "4.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/minimist-options/-/minimist-options-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
       "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
       "dev": true,
       "requires": {
@@ -17618,7 +17663,7 @@
     },
     "minipass": {
       "version": "3.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/minipass/-/minipass-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
       "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
       "dev": true,
       "requires": {
@@ -17627,7 +17672,7 @@
       "dependencies": {
         "yallist": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/yallist/-/yallist-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
@@ -17635,7 +17680,7 @@
     },
     "minipass-collect": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
       "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
       "dev": true,
       "requires": {
@@ -17644,7 +17689,7 @@
     },
     "minipass-flush": {
       "version": "1.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
       "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
       "dev": true,
       "requires": {
@@ -17662,7 +17707,7 @@
     },
     "mississippi": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/mississippi/-/mississippi-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
       "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "dev": true,
       "requires": {
@@ -17680,7 +17725,7 @@
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
@@ -17690,7 +17735,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
@@ -17716,7 +17761,7 @@
     },
     "mkdirp": {
       "version": "0.5.5",
-      "resolved": "https://npm.americanwhitewater.org:443/mkdirp/-/mkdirp-0.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
@@ -17725,7 +17770,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.5",
-          "resolved": "https://npm.americanwhitewater.org:443/minimist/-/minimist-1.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
@@ -17738,7 +17783,7 @@
     },
     "move-concurrently": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
@@ -17752,12 +17797,12 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multicast-dns": {
       "version": "6.2.3",
-      "resolved": "https://npm.americanwhitewater.org:443/multicast-dns/-/multicast-dns-6.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "dev": true,
       "requires": {
@@ -17767,24 +17812,24 @@
     },
     "multicast-dns-service-types": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
     "murmurhash-js": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
     },
     "mute-stream": {
       "version": "0.0.8",
-      "resolved": "https://npm.americanwhitewater.org:443/mute-stream/-/mute-stream-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "mz": {
       "version": "2.7.0",
-      "resolved": "https://npm.americanwhitewater.org:443/mz/-/mz-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
@@ -17806,7 +17851,7 @@
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://npm.americanwhitewater.org:443/nanomatch/-/nanomatch-1.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
@@ -17825,19 +17870,19 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "natural-orderby": {
       "version": "2.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/natural-orderby/-/natural-orderby-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
       "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==",
       "dev": true
     },
     "negotiator": {
       "version": "0.6.2",
-      "resolved": "https://npm.americanwhitewater.org:443/negotiator/-/negotiator-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "neo-async": {
@@ -17848,13 +17893,13 @@
     },
     "nice-try": {
       "version": "1.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/nice-try/-/nice-try-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/no-case/-/no-case-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
@@ -17869,7 +17914,7 @@
     },
     "node-cache": {
       "version": "4.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/node-cache/-/node-cache-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
       "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
       "dev": true,
       "requires": {
@@ -17879,7 +17924,7 @@
       "dependencies": {
         "clone": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/clone/-/clone-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
           "dev": true
         }
@@ -17899,7 +17944,7 @@
     },
     "node-gyp": {
       "version": "3.8.0",
-      "resolved": "https://npm.americanwhitewater.org:443/node-gyp/-/node-gyp-3.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
       "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
       "dev": true,
       "requires": {
@@ -17919,7 +17964,7 @@
       "dependencies": {
         "nopt": {
           "version": "3.0.6",
-          "resolved": "https://npm.americanwhitewater.org:443/nopt/-/nopt-3.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
@@ -17928,7 +17973,7 @@
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -17936,13 +17981,13 @@
     },
     "node-int64": {
       "version": "0.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
     "node-ipc": {
       "version": "9.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/node-ipc/-/node-ipc-9.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.1.1.tgz",
       "integrity": "sha512-FAyICv0sIRJxVp3GW5fzgaf9jwwRQxAKDJlmNFUL5hOy+W4X/I5AypyHoq0DXXbo9o/gt79gj++4cMr4jVWE/w==",
       "dev": true,
       "requires": {
@@ -17953,7 +17998,7 @@
     },
     "node-libs-browser": {
       "version": "2.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
       "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "dev": true,
       "requires": {
@@ -17984,7 +18029,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://npm.americanwhitewater.org:443/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
@@ -17992,13 +18037,13 @@
     },
     "node-modules-regexp": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
       "dev": true
     },
     "node-notifier": {
       "version": "5.4.3",
-      "resolved": "https://npm.americanwhitewater.org:443/node-notifier/-/node-notifier-5.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
       "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
       "dev": true,
       "requires": {
@@ -18017,7 +18062,7 @@
     },
     "node-sass": {
       "version": "4.14.1",
-      "resolved": "https://npm.americanwhitewater.org:443/node-sass/-/node-sass-4.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
       "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
       "dev": true,
       "requires": {
@@ -18042,19 +18087,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18067,7 +18112,7 @@
         },
         "cross-spawn": {
           "version": "3.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
@@ -18083,13 +18128,13 @@
         },
         "get-stdin": {
           "version": "4.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/get-stdin/-/get-stdin-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
           "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/lru-cache/-/lru-cache-4.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
@@ -18099,7 +18144,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -18108,13 +18153,13 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -18122,7 +18167,7 @@
     },
     "nodemon": {
       "version": "1.19.4",
-      "resolved": "https://npm.americanwhitewater.org:443/nodemon/-/nodemon-1.19.4.tgz",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.4.tgz",
       "integrity": "sha512-VGPaqQBNk193lrJFotBU8nvWZPqEZY2eIzymy2jjY0fJ9qIsxA0sxQ8ATPl0gZC645gijYEc1jtZvpS8QWzJGQ==",
       "dev": true,
       "requires": {
@@ -18140,7 +18185,7 @@
       "dependencies": {
         "anymatch": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/anymatch/-/anymatch-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
@@ -18150,7 +18195,7 @@
           "dependencies": {
             "normalize-path": {
               "version": "2.1.1",
-              "resolved": "https://npm.americanwhitewater.org:443/normalize-path/-/normalize-path-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
               "dev": true,
               "requires": {
@@ -18161,13 +18206,13 @@
         },
         "binary-extensions": {
           "version": "1.13.1",
-          "resolved": "https://npm.americanwhitewater.org:443/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
           "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
           "dev": true
         },
         "chokidar": {
           "version": "2.1.8",
-          "resolved": "https://npm.americanwhitewater.org:443/chokidar/-/chokidar-2.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
           "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
           "dev": true,
           "requires": {
@@ -18187,7 +18232,7 @@
         },
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://npm.americanwhitewater.org:443/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
@@ -18196,7 +18241,7 @@
         },
         "fsevents": {
           "version": "1.2.13",
-          "resolved": "https://npm.americanwhitewater.org:443/fsevents/-/fsevents-1.2.13.tgz",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
           "optional": true,
@@ -18207,7 +18252,7 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -18217,7 +18262,7 @@
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
-              "resolved": "https://npm.americanwhitewater.org:443/is-glob/-/is-glob-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
@@ -18228,7 +18273,7 @@
         },
         "is-binary-path": {
           "version": "1.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "dev": true,
           "requires": {
@@ -18237,13 +18282,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "readdirp": {
           "version": "2.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/readdirp/-/readdirp-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
           "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
           "dev": true,
           "requires": {
@@ -18256,7 +18301,7 @@
     },
     "nomnom": {
       "version": "1.8.1",
-      "resolved": "https://npm.americanwhitewater.org:443/nomnom/-/nomnom-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "requires": {
         "chalk": "~0.4.0",
@@ -18274,7 +18319,7 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -18285,31 +18330,31 @@
     },
     "normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/normalize-path/-/normalize-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
     "normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/normalize-range/-/normalize-range-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
     "normalize-selector": {
       "version": "0.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/normalize-selector/-/normalize-selector-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
       "dev": true
     },
     "normalize-url": {
       "version": "3.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/normalize-url/-/normalize-url-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
       "dev": true
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
@@ -18318,7 +18363,7 @@
     },
     "npmlog": {
       "version": "4.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/npmlog/-/npmlog-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
@@ -18330,7 +18375,7 @@
     },
     "nth-check": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/nth-check/-/nth-check-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dev": true,
       "requires": {
@@ -18339,36 +18384,36 @@
     },
     "num2fraction": {
       "version": "1.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/num2fraction/-/num2fraction-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/nwsapi/-/nwsapi-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -18379,7 +18424,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://npm.americanwhitewater.org:443/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -18388,13 +18433,13 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "https://npm.americanwhitewater.org:443/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.americanwhitewater.org:443/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -18405,13 +18450,13 @@
     },
     "object-hash": {
       "version": "1.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/object-hash/-/object-hash-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
       "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
       "dev": true
     },
     "object-inspect": {
       "version": "1.8.0",
-      "resolved": "https://npm.americanwhitewater.org:443/object-inspect/-/object-inspect-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
       "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
     },
     "object-is": {
@@ -18448,7 +18493,7 @@
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-path": {
@@ -18465,7 +18510,7 @@
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -18493,7 +18538,7 @@
     },
     "object.getownpropertydescriptors": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
       "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "dev": true,
       "requires": {
@@ -18503,7 +18548,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
@@ -18520,7 +18565,7 @@
     },
     "object.values": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/object.values/-/object.values-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
       "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
       "requires": {
         "define-properties": "^1.1.3",
@@ -18531,13 +18576,13 @@
     },
     "obuf": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/obuf/-/obuf-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
@@ -18545,13 +18590,13 @@
     },
     "on-headers": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/on-headers/-/on-headers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "dev": true
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -18560,7 +18605,7 @@
     },
     "onetime": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/onetime/-/onetime-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
@@ -18569,7 +18614,7 @@
     },
     "open": {
       "version": "6.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/open/-/open-6.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
       "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
       "dev": true,
       "requires": {
@@ -18584,7 +18629,7 @@
     },
     "opn": {
       "version": "5.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/opn/-/opn-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
       "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
       "dev": true,
       "requires": {
@@ -18601,7 +18646,7 @@
     },
     "optionator": {
       "version": "0.8.3",
-      "resolved": "https://npm.americanwhitewater.org:443/optionator/-/optionator-0.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
@@ -18615,7 +18660,7 @@
     },
     "ora": {
       "version": "3.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/ora/-/ora-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
       "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
       "dev": true,
       "requires": {
@@ -18629,13 +18674,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -18644,7 +18689,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -18661,7 +18706,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -18672,12 +18717,12 @@
     },
     "orderedmap": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/orderedmap/-/orderedmap-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.1.tgz",
       "integrity": "sha512-3Ux8um0zXbVacKUkcytc0u3HgC0b0bBLT+I60r2J/En72cI0nZffqrA7Xtf2Hqs27j1g82llR5Mhbd0Z1XW4AQ=="
     },
     "original": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/original/-/original-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
       "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
       "dev": true,
       "requires": {
@@ -18686,25 +18731,25 @@
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/os-browserify/-/os-browserify-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "osenv": {
       "version": "0.1.5",
-      "resolved": "https://npm.americanwhitewater.org:443/osenv/-/osenv-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
@@ -18714,7 +18759,7 @@
     },
     "p-each-series": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/p-each-series/-/p-each-series-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "dev": true,
       "requires": {
@@ -18723,7 +18768,7 @@
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
@@ -18745,7 +18790,7 @@
     },
     "p-map": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/p-map/-/p-map-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
       "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
       "dev": true,
       "requires": {
@@ -18754,13 +18799,13 @@
     },
     "p-reduce": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/p-reduce/-/p-reduce-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
       "dev": true
     },
     "p-retry": {
       "version": "3.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/p-retry/-/p-retry-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
       "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
       "dev": true,
       "requires": {
@@ -18774,7 +18819,7 @@
     },
     "package-json": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/package-json/-/package-json-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
@@ -18786,13 +18831,13 @@
     },
     "pako": {
       "version": "1.0.11",
-      "resolved": "https://npm.americanwhitewater.org:443/pako/-/pako-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
     },
     "parallel-transform": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/parallel-transform/-/parallel-transform-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
       "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
       "dev": true,
       "requires": {
@@ -18803,7 +18848,7 @@
     },
     "param-case": {
       "version": "2.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/param-case/-/param-case-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
@@ -18812,7 +18857,7 @@
     },
     "parent-module": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/parent-module/-/parent-module-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
@@ -18834,7 +18879,7 @@
     },
     "parse-entities": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/parse-entities/-/parse-entities-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
       "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
       "dev": true,
       "requires": {
@@ -18883,13 +18928,13 @@
     },
     "parse5": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/parse5/-/parse5-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
     "parse5-htmlparser2-tree-adapter": {
       "version": "5.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-5.1.1.tgz",
       "integrity": "sha512-CF+TKjXqoqyDwHqBhFQ+3l5t83xYi6fVT1tQNg+Ye0JRLnTxWvIroCjEp1A0k4lneHNBGnICUf0cfYVYGEazqw==",
       "dev": true,
       "requires": {
@@ -18898,7 +18943,7 @@
       "dependencies": {
         "parse5": {
           "version": "5.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/parse5/-/parse5-5.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
           "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
           "dev": true
         }
@@ -18906,7 +18951,7 @@
     },
     "parseurl": {
       "version": "1.3.3",
-      "resolved": "https://npm.americanwhitewater.org:443/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "pascal-case": {
@@ -18942,13 +18987,13 @@
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "password-prompt": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/password-prompt/-/password-prompt-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz",
       "integrity": "sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==",
       "dev": true,
       "requires": {
@@ -18958,7 +19003,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
           "dev": true
         }
@@ -18966,7 +19011,7 @@
     },
     "path-browserify": {
       "version": "0.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/path-browserify/-/path-browserify-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
     },
@@ -18982,41 +19027,41 @@
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/path-parse/-/path-parse-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://npm.americanwhitewater.org:443/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
@@ -19029,7 +19074,7 @@
     },
     "pbf": {
       "version": "3.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/pbf/-/pbf-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
       "requires": {
         "ieee754": "^1.1.12",
@@ -19038,7 +19083,7 @@
     },
     "pbkdf2": {
       "version": "3.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
       "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
       "dev": true,
       "requires": {
@@ -19051,13 +19096,13 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "picomatch": {
       "version": "2.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/picomatch/-/picomatch-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
@@ -19068,13 +19113,13 @@
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -19083,7 +19128,7 @@
     },
     "pirates": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/pirates/-/pirates-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
       "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
       "dev": true,
       "requires": {
@@ -19100,7 +19145,7 @@
     },
     "please-upgrade-node": {
       "version": "3.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
       "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
       "dev": true,
       "requires": {
@@ -19109,13 +19154,13 @@
     },
     "pn": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/pn/-/pn-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
     "pnp-webpack-plugin": {
       "version": "1.6.4",
-      "resolved": "https://npm.americanwhitewater.org:443/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz",
       "integrity": "sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==",
       "dev": true,
       "requires": {
@@ -19135,7 +19180,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://npm.americanwhitewater.org:443/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
@@ -19144,7 +19189,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -19152,7 +19197,7 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
@@ -19239,7 +19284,7 @@
     },
     "postcss-colormin": {
       "version": "4.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
       "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
       "dev": true,
       "requires": {
@@ -19300,7 +19345,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -19317,7 +19362,7 @@
     },
     "postcss-convert-values": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
       "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
       "dev": true,
       "requires": {
@@ -19375,7 +19420,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -19392,7 +19437,7 @@
     },
     "postcss-discard-comments": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
       "integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
       "dev": true,
       "requires": {
@@ -19460,7 +19505,7 @@
     },
     "postcss-discard-duplicates": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
       "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
       "dev": true,
       "requires": {
@@ -19528,7 +19573,7 @@
     },
     "postcss-discard-empty": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
       "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
       "dev": true,
       "requires": {
@@ -19596,7 +19641,7 @@
     },
     "postcss-discard-overridden": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
       "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
       "dev": true,
       "requires": {
@@ -19664,7 +19709,7 @@
     },
     "postcss-html": {
       "version": "0.36.0",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-html/-/postcss-html-0.36.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
       "integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
       "dev": true,
       "requires": {
@@ -19697,13 +19742,13 @@
         },
         "domelementtype": {
           "version": "1.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/domelementtype/-/domelementtype-1.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
           "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
           "dev": true
         },
         "domhandler": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/domhandler/-/domhandler-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "dev": true,
           "requires": {
@@ -19712,7 +19757,7 @@
         },
         "domutils": {
           "version": "1.7.0",
-          "resolved": "https://npm.americanwhitewater.org:443/domutils/-/domutils-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
           "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
           "dev": true,
           "requires": {
@@ -19722,13 +19767,13 @@
         },
         "entities": {
           "version": "1.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/entities/-/entities-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
           "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
           "dev": true
         },
         "htmlparser2": {
           "version": "3.10.1",
-          "resolved": "https://npm.americanwhitewater.org:443/htmlparser2/-/htmlparser2-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
           "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
           "dev": true,
           "requires": {
@@ -19742,7 +19787,7 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://npm.americanwhitewater.org:443/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
@@ -19755,7 +19800,7 @@
     },
     "postcss-less": {
       "version": "3.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-less/-/postcss-less-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
       "integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
       "dev": true,
       "requires": {
@@ -19833,7 +19878,7 @@
     },
     "postcss-loader": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-loader/-/postcss-loader-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
       "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
       "dev": true,
       "requires": {
@@ -19893,7 +19938,7 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/schema-utils/-/schema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
@@ -19915,13 +19960,13 @@
     },
     "postcss-media-query-parser": {
       "version": "0.2.3",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
       "dev": true
     },
     "postcss-merge-longhand": {
       "version": "4.0.11",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
       "integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
       "dev": true,
       "requires": {
@@ -19981,7 +20026,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -19998,7 +20043,7 @@
     },
     "postcss-merge-rules": {
       "version": "4.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
       "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
       "dev": true,
       "requires": {
@@ -20060,7 +20105,7 @@
         },
         "postcss-selector-parser": {
           "version": "3.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
           "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
           "dev": true,
           "requires": {
@@ -20082,7 +20127,7 @@
     },
     "postcss-minify-font-values": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
       "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
       "dev": true,
       "requires": {
@@ -20140,7 +20185,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -20157,7 +20202,7 @@
     },
     "postcss-minify-gradients": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
       "integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
       "dev": true,
       "requires": {
@@ -20217,7 +20262,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -20234,7 +20279,7 @@
     },
     "postcss-minify-params": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
       "integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
       "dev": true,
       "requires": {
@@ -20296,7 +20341,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -20313,7 +20358,7 @@
     },
     "postcss-minify-selectors": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
       "integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
       "dev": true,
       "requires": {
@@ -20373,7 +20418,7 @@
         },
         "postcss-selector-parser": {
           "version": "3.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
           "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
           "dev": true,
           "requires": {
@@ -20395,7 +20440,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
       "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
       "dev": true,
       "requires": {
@@ -20534,7 +20579,7 @@
     },
     "postcss-modules-scope": {
       "version": "2.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
       "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
       "dev": true,
       "requires": {
@@ -20603,7 +20648,7 @@
     },
     "postcss-modules-values": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
       "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
       "dev": true,
       "requires": {
@@ -20672,7 +20717,7 @@
     },
     "postcss-normalize-charset": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
       "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
       "dev": true,
       "requires": {
@@ -20740,7 +20785,7 @@
     },
     "postcss-normalize-display-values": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
       "integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
       "dev": true,
       "requires": {
@@ -20799,7 +20844,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -20816,7 +20861,7 @@
     },
     "postcss-normalize-positions": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
       "integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
       "dev": true,
       "requires": {
@@ -20876,7 +20921,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -20893,7 +20938,7 @@
     },
     "postcss-normalize-repeat-style": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
       "integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
       "dev": true,
       "requires": {
@@ -20953,7 +20998,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -20970,7 +21015,7 @@
     },
     "postcss-normalize-string": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
       "integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
       "dev": true,
       "requires": {
@@ -21029,7 +21074,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -21046,7 +21091,7 @@
     },
     "postcss-normalize-timing-functions": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
       "integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
       "dev": true,
       "requires": {
@@ -21105,7 +21150,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -21122,7 +21167,7 @@
     },
     "postcss-normalize-unicode": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
       "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
       "dev": true,
       "requires": {
@@ -21181,7 +21226,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -21198,7 +21243,7 @@
     },
     "postcss-normalize-url": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
       "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
       "dev": true,
       "requires": {
@@ -21258,7 +21303,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -21275,7 +21320,7 @@
     },
     "postcss-normalize-whitespace": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
       "integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
       "dev": true,
       "requires": {
@@ -21333,7 +21378,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -21350,7 +21395,7 @@
     },
     "postcss-ordered-values": {
       "version": "4.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
       "integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
       "dev": true,
       "requires": {
@@ -21409,7 +21454,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -21426,7 +21471,7 @@
     },
     "postcss-reduce-initial": {
       "version": "4.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
       "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
       "dev": true,
       "requires": {
@@ -21497,7 +21542,7 @@
     },
     "postcss-reduce-transforms": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
       "integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
       "dev": true,
       "requires": {
@@ -21557,7 +21602,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -21574,13 +21619,13 @@
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
       "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
       "dev": true
     },
     "postcss-safe-parser": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz",
       "integrity": "sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==",
       "dev": true,
       "requires": {
@@ -21648,7 +21693,7 @@
     },
     "postcss-sass": {
       "version": "0.4.4",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-sass/-/postcss-sass-0.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.4.tgz",
       "integrity": "sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==",
       "dev": true,
       "requires": {
@@ -21717,7 +21762,7 @@
     },
     "postcss-scss": {
       "version": "2.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-scss/-/postcss-scss-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
       "integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
       "dev": true,
       "requires": {
@@ -21797,7 +21842,7 @@
     },
     "postcss-sorting": {
       "version": "5.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-sorting/-/postcss-sorting-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.1.tgz",
       "integrity": "sha512-Y9fUFkIhfrm6i0Ta3n+89j56EFqaNRdUKqXyRp6kvTcSXnmgEjaVowCXH+JBe9+YKWqd4nc28r2sgwnzJalccA==",
       "dev": true,
       "requires": {
@@ -21866,7 +21911,7 @@
     },
     "postcss-svgo": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
       "integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
       "dev": true,
       "requires": {
@@ -21926,7 +21971,7 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
@@ -21943,13 +21988,13 @@
     },
     "postcss-syntax": {
       "version": "0.36.2",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
       "dev": true
     },
     "postcss-unique-selectors": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
       "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
       "dev": true,
       "requires": {
@@ -22019,24 +22064,24 @@
     },
     "postcss-value-parser": {
       "version": "4.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
     "potpack": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/potpack/-/potpack-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.1.tgz",
       "integrity": "sha512-15vItUAbViaYrmaB/Pbw7z6qX2xENbFSTA7Ii4tgbPtasxm5v6ryKhKtL91tpWovDJzTiZqdwzhcFBCwiMVdVw=="
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/prepend-http/-/prepend-http-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
@@ -22048,7 +22093,7 @@
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
       "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
       "dev": true,
       "requires": {
@@ -22057,7 +22102,7 @@
     },
     "pretty": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/pretty/-/pretty-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
       "integrity": "sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=",
       "dev": true,
       "requires": {
@@ -22068,7 +22113,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -22095,7 +22140,7 @@
     },
     "pretty-format": {
       "version": "24.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/pretty-format/-/pretty-format-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
       "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
       "dev": true,
       "requires": {
@@ -22107,13 +22152,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -22124,24 +22169,24 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://npm.americanwhitewater.org:443/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/progress/-/progress-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
@@ -22167,7 +22212,7 @@
     },
     "prosemirror-collab": {
       "version": "1.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
       "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
       "requires": {
         "prosemirror-state": "^1.0.0"
@@ -22175,7 +22220,7 @@
     },
     "prosemirror-commands": {
       "version": "1.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/prosemirror-commands/-/prosemirror-commands-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.1.4.tgz",
       "integrity": "sha512-kj4Qi+8h3EpJtZuuEDwZ9h2/QNGWDsIX/CzjmClxi9GhxWyBUMVUvIFk0mgdqHyX20lLeGmOpc0TLA5aPzgpWg==",
       "requires": {
         "prosemirror-model": "^1.0.0",
@@ -22185,7 +22230,7 @@
     },
     "prosemirror-dropcursor": {
       "version": "1.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/prosemirror-dropcursor/-/prosemirror-dropcursor-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.3.2.tgz",
       "integrity": "sha512-4c94OUGyobGnwcQI70OXyMhE/9T4aTgjU+CHxkd5c7D+jH/J0mKM/lk+jneFVKt7+E4/M0D9HzRPifu8U28Thw==",
       "requires": {
         "prosemirror-state": "^1.0.0",
@@ -22195,7 +22240,7 @@
     },
     "prosemirror-gapcursor": {
       "version": "1.1.5",
-      "resolved": "https://npm.americanwhitewater.org:443/prosemirror-gapcursor/-/prosemirror-gapcursor-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.1.5.tgz",
       "integrity": "sha512-SjbUZq5pgsBDuV3hu8GqgIpZR5eZvGLM+gPQTqjVVYSMUCfKW3EGXTEYaLHEl1bGduwqNC95O3bZflgtAb4L6w==",
       "requires": {
         "prosemirror-keymap": "^1.0.0",
@@ -22206,7 +22251,7 @@
     },
     "prosemirror-history": {
       "version": "1.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/prosemirror-history/-/prosemirror-history-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.1.3.tgz",
       "integrity": "sha512-zGDotijea+vnfnyyUGyiy1wfOQhf0B/b6zYcCouBV8yo6JmrE9X23M5q7Nf/nATywEZbgRLG70R4DmfSTC+gfg==",
       "requires": {
         "prosemirror-state": "^1.2.2",
@@ -22216,7 +22261,7 @@
     },
     "prosemirror-inputrules": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/prosemirror-inputrules/-/prosemirror-inputrules-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.2.tgz",
       "integrity": "sha512-Ja5Z3BWestlHYGvtSGqyvxMeB8QEuBjlHM8YnKtLGUXMDp965qdDV4goV8lJb17kIWHk7e7JNj6Catuoa3302g==",
       "requires": {
         "prosemirror-state": "^1.0.0",
@@ -22251,7 +22296,7 @@
     },
     "prosemirror-state": {
       "version": "1.3.3",
-      "resolved": "https://npm.americanwhitewater.org:443/prosemirror-state/-/prosemirror-state-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.3.tgz",
       "integrity": "sha512-PLXh2VJsIgvlgSTH6I2Yg6vk1CzPDp21DFreVpQtDMY2S6WaMmrQgDTLRcsrD8X38v8Yc873H7+ogdGzyIPn+w==",
       "requires": {
         "prosemirror-model": "^1.0.0",
@@ -22280,7 +22325,7 @@
     },
     "prosemirror-utils": {
       "version": "0.9.6",
-      "resolved": "https://npm.americanwhitewater.org:443/prosemirror-utils/-/prosemirror-utils-0.9.6.tgz",
+      "resolved": "https://registry.npmjs.org/prosemirror-utils/-/prosemirror-utils-0.9.6.tgz",
       "integrity": "sha512-UC+j9hQQ1POYfMc5p7UFxBTptRiGPR7Kkmbl3jVvU8VgQbkI89tR/GK+3QYC8n+VvBZrtAoCrJItNhWSxX3slA=="
     },
     "prosemirror-view": {
@@ -22295,13 +22340,13 @@
     },
     "proto-list": {
       "version": "1.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/proto-list/-/proto-list-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
     },
     "protocol-buffers-schema": {
       "version": "3.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
       "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
     },
     "protocols": {
@@ -22312,7 +22357,7 @@
     },
     "proxy-addr": {
       "version": "2.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
       "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
       "requires": {
         "forwarded": "~0.1.2",
@@ -22321,31 +22366,31 @@
     },
     "prr": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/prr/-/prr-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "psl": {
       "version": "1.8.0",
-      "resolved": "https://npm.americanwhitewater.org:443/psl/-/psl-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
     "pstree.remy": {
       "version": "1.1.8",
-      "resolved": "https://npm.americanwhitewater.org:443/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "requires": {
@@ -22359,7 +22404,7 @@
       "dependencies": {
         "bn.js": {
           "version": "4.11.9",
-          "resolved": "https://npm.americanwhitewater.org:443/bn.js/-/bn.js-4.11.9.tgz",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
@@ -22367,7 +22412,7 @@
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/pump/-/pump-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
@@ -22377,7 +22422,7 @@
     },
     "pumpify": {
       "version": "1.5.1",
-      "resolved": "https://npm.americanwhitewater.org:443/pumpify/-/pumpify-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
@@ -22388,7 +22433,7 @@
       "dependencies": {
         "pump": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/pump/-/pump-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
@@ -22400,24 +22445,24 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "https://npm.americanwhitewater.org:443/q/-/q-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "qs": {
       "version": "6.7.0",
-      "resolved": "https://npm.americanwhitewater.org:443/qs/-/qs-6.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "query-string": {
       "version": "4.3.4",
-      "resolved": "https://npm.americanwhitewater.org:443/query-string/-/query-string-4.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "dev": true,
       "requires": {
@@ -22427,13 +22472,13 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
@@ -22445,18 +22490,18 @@
     },
     "quick-lru": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/quick-lru/-/quick-lru-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
     "quickselect": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/quickselect/-/quickselect-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
       "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/randombytes/-/randombytes-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
@@ -22465,7 +22510,7 @@
     },
     "randomfill": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/randomfill/-/randomfill-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
@@ -22475,12 +22520,12 @@
     },
     "range-parser": {
       "version": "1.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/range-parser/-/range-parser-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
       "version": "2.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/raw-body/-/raw-body-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
       "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
       "requires": {
         "bytes": "3.1.0",
@@ -22491,7 +22536,7 @@
     },
     "rbush": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/rbush/-/rbush-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
       "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
       "requires": {
         "quickselect": "^1.0.1"
@@ -22499,7 +22544,7 @@
     },
     "rbush-knn": {
       "version": "3.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/rbush-knn/-/rbush-knn-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/rbush-knn/-/rbush-knn-3.0.1.tgz",
       "integrity": "sha512-nuehTm0Q8yR6nvu3XjoWnZVGK5QqqRHNWogRIjBEBcPgsq3pbiuvWuq0/e/1uL43fXNtDUv93kYZDStZonBetQ==",
       "requires": {
         "tinyqueue": "^2.0.3"
@@ -22507,7 +22552,7 @@
     },
     "rc": {
       "version": "1.2.8",
-      "resolved": "https://npm.americanwhitewater.org:443/rc/-/rc-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
@@ -22519,7 +22564,7 @@
     },
     "react-is": {
       "version": "16.13.1",
-      "resolved": "https://npm.americanwhitewater.org:443/react-is/-/react-is-16.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "read-pkg": {
@@ -22543,7 +22588,7 @@
     },
     "readable-stream": {
       "version": "2.3.7",
-      "resolved": "https://npm.americanwhitewater.org:443/readable-stream/-/readable-stream-2.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -22567,7 +22612,7 @@
     },
     "realpath-native": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/realpath-native/-/realpath-native-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
       "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
       "dev": true,
       "requires": {
@@ -22596,7 +22641,7 @@
     },
     "rechoir": {
       "version": "0.6.2",
-      "resolved": "https://npm.americanwhitewater.org:443/rechoir/-/rechoir-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
@@ -22605,7 +22650,7 @@
     },
     "redent": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/redent/-/redent-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
@@ -22615,13 +22660,13 @@
       "dependencies": {
         "get-stdin": {
           "version": "4.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/get-stdin/-/get-stdin-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
           "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
           "dev": true
         },
         "indent-string": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/indent-string/-/indent-string-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
@@ -22630,7 +22675,7 @@
         },
         "strip-indent": {
           "version": "1.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-indent/-/strip-indent-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
@@ -22641,7 +22686,7 @@
     },
     "redeyed": {
       "version": "2.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/redeyed/-/redeyed-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
       "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
       "dev": true,
       "requires": {
@@ -22656,7 +22701,7 @@
     },
     "regenerate-unicode-properties": {
       "version": "8.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
       "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
       "dev": true,
       "requires": {
@@ -22679,7 +22724,7 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/regex-not/-/regex-not-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
@@ -22689,7 +22734,7 @@
     },
     "regexp.prototype.flags": {
       "version": "1.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "dev": true,
       "requires": {
@@ -22699,7 +22744,7 @@
     },
     "regexpp": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/regexpp/-/regexpp-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
@@ -22719,12 +22764,12 @@
     },
     "register-service-worker": {
       "version": "1.7.1",
-      "resolved": "https://npm.americanwhitewater.org:443/register-service-worker/-/register-service-worker-1.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/register-service-worker/-/register-service-worker-1.7.1.tgz",
       "integrity": "sha512-IdTfUZ4u8iJL8o1w8es8l6UMGPmkwHolUdT+UmM1UypC80IB4KbpuIlvwWVj8UDS7eJwkEYRcKRgfRX+oTmJsw=="
     },
     "registry-auth-token": {
       "version": "3.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
       "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "dev": true,
       "requires": {
@@ -22734,7 +22779,7 @@
     },
     "registry-url": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/registry-url/-/registry-url-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
@@ -22743,13 +22788,13 @@
     },
     "regjsgen": {
       "version": "0.5.2",
-      "resolved": "https://npm.americanwhitewater.org:443/regjsgen/-/regjsgen-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
       "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
       "dev": true
     },
     "regjsparser": {
       "version": "0.6.4",
-      "resolved": "https://npm.americanwhitewater.org:443/regjsparser/-/regjsparser-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
       "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
       "dev": true,
       "requires": {
@@ -22758,7 +22803,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://npm.americanwhitewater.org:443/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -22766,7 +22811,7 @@
     },
     "relateurl": {
       "version": "0.2.7",
-      "resolved": "https://npm.americanwhitewater.org:443/relateurl/-/relateurl-0.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
@@ -22829,7 +22874,7 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
@@ -22848,13 +22893,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "css-select": {
           "version": "1.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/css-select/-/css-select-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
           "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
           "dev": true,
           "requires": {
@@ -22866,7 +22911,7 @@
         },
         "css-what": {
           "version": "2.1.3",
-          "resolved": "https://npm.americanwhitewater.org:443/css-what/-/css-what-2.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
           "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
           "dev": true
         },
@@ -22890,13 +22935,13 @@
         },
         "domelementtype": {
           "version": "1.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/domelementtype/-/domelementtype-1.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
           "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
           "dev": true
         },
         "domhandler": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/domhandler/-/domhandler-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "dev": true,
           "requires": {
@@ -22905,7 +22950,7 @@
         },
         "domutils": {
           "version": "1.5.1",
-          "resolved": "https://npm.americanwhitewater.org:443/domutils/-/domutils-1.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "dev": true,
           "requires": {
@@ -22915,7 +22960,7 @@
         },
         "htmlparser2": {
           "version": "3.10.1",
-          "resolved": "https://npm.americanwhitewater.org:443/htmlparser2/-/htmlparser2-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
           "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
           "dev": true,
           "requires": {
@@ -22937,7 +22982,7 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://npm.americanwhitewater.org:443/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
@@ -22948,7 +22993,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -22959,18 +23004,18 @@
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/repeat-element/-/repeat-element-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://npm.americanwhitewater.org:443/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
@@ -22979,12 +23024,12 @@
     },
     "replace-ext": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/replace-ext/-/replace-ext-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
       "version": "2.88.2",
-      "resolved": "https://npm.americanwhitewater.org:443/request/-/request-2.88.2.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
@@ -23012,7 +23057,7 @@
       "dependencies": {
         "qs": {
           "version": "6.5.2",
-          "resolved": "https://npm.americanwhitewater.org:443/qs/-/qs-6.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         }
@@ -23040,19 +23085,19 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
@@ -23067,7 +23112,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -23076,13 +23121,13 @@
     },
     "resolve-from": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/resolve-from/-/resolve-from-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
     "resolve-protobuf-schema": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
       "requires": {
         "protocol-buffers-schema": "^3.3.1"
@@ -23090,13 +23135,13 @@
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "restore-cursor": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
@@ -23106,37 +23151,37 @@
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "https://npm.americanwhitewater.org:443/ret/-/ret-0.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
     "retry": {
       "version": "0.12.0",
-      "resolved": "https://npm.americanwhitewater.org:443/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
     "reusify": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/reusify/-/reusify-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
     "rgb-regex": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/rgb-regex/-/rgb-regex-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
       "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
       "dev": true
     },
     "rgba-regex": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
     },
     "rimraf": {
       "version": "2.7.1",
-      "resolved": "https://npm.americanwhitewater.org:443/rimraf/-/rimraf-2.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
@@ -23145,7 +23190,7 @@
     },
     "ripemd160": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/ripemd160/-/ripemd160-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
@@ -23155,18 +23200,18 @@
     },
     "rope-sequence": {
       "version": "1.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/rope-sequence/-/rope-sequence-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.2.tgz",
       "integrity": "sha512-ku6MFrwEVSVmXLvy3dYph3LAMNS0890K7fabn+0YIRQ2T96T9F4gkFf0vf0WW0JUraNWwGRtInEpH7yO4tbQZg=="
     },
     "rsvp": {
       "version": "4.8.5",
-      "resolved": "https://npm.americanwhitewater.org:443/rsvp/-/rsvp-4.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
     "run-async": {
       "version": "2.4.1",
-      "resolved": "https://npm.americanwhitewater.org:443/run-async/-/run-async-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "dev": true
     },
@@ -23178,7 +23223,7 @@
     },
     "run-queue": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/run-queue/-/run-queue-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
@@ -23187,7 +23232,7 @@
     },
     "rw": {
       "version": "0.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/rw/-/rw-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-0.1.4.tgz",
       "integrity": "sha1-SQPL2AJIrg7eaFv1j9I2p6mymj4="
     },
     "rxjs": {
@@ -23201,12 +23246,12 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -23215,12 +23260,12 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/sane/-/sane-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
       "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
       "dev": true,
       "requires": {
@@ -23237,7 +23282,7 @@
       "dependencies": {
         "anymatch": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/anymatch/-/anymatch-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
@@ -23247,7 +23292,7 @@
         },
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/normalize-path/-/normalize-path-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
@@ -23272,7 +23317,7 @@
     },
     "sass-graph": {
       "version": "2.2.5",
-      "resolved": "https://npm.americanwhitewater.org:443/sass-graph/-/sass-graph-2.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
       "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
       "dev": true,
       "requires": {
@@ -23284,7 +23329,7 @@
     },
     "sass-loader": {
       "version": "8.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/sass-loader/-/sass-loader-8.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
       "integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
       "dev": true,
       "requires": {
@@ -23297,7 +23342,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -23305,13 +23350,13 @@
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/sax/-/sax-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "saxes": {
       "version": "3.1.11",
-      "resolved": "https://npm.americanwhitewater.org:443/saxes/-/saxes-3.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
       "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
       "dev": true,
       "requires": {
@@ -23331,7 +23376,7 @@
     },
     "screenfull": {
       "version": "5.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/screenfull/-/screenfull-5.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.0.2.tgz",
       "integrity": "sha512-cCF2b+L/mnEiORLN5xSAz6H3t18i2oHh9BA8+CQlAh5DRw2+NFAGQJOSYbcGw8B2k04g/lVvFcfZ83b3ysH5UQ=="
     },
     "scroll-into-view-if-needed": {
@@ -23344,7 +23389,7 @@
     },
     "scss-tokenizer": {
       "version": "0.2.3",
-      "resolved": "https://npm.americanwhitewater.org:443/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
@@ -23354,7 +23399,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://npm.americanwhitewater.org:443/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -23365,7 +23410,7 @@
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/select-hose/-/select-hose-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
@@ -23380,18 +23425,18 @@
     },
     "semver": {
       "version": "5.7.1",
-      "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-5.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/semver-compare/-/semver-compare-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "semver-diff": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/semver-diff/-/semver-diff-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
@@ -23400,7 +23445,7 @@
     },
     "send": {
       "version": "0.17.1",
-      "resolved": "https://npm.americanwhitewater.org:443/send/-/send-0.17.1.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
       "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "requires": {
         "debug": "2.6.9",
@@ -23420,7 +23465,7 @@
       "dependencies": {
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
@@ -23468,7 +23513,7 @@
     },
     "serve-index": {
       "version": "1.9.1",
-      "resolved": "https://npm.americanwhitewater.org:443/serve-index/-/serve-index-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
@@ -23483,7 +23528,7 @@
       "dependencies": {
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "https://npm.americanwhitewater.org:443/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
@@ -23495,13 +23540,13 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         }
@@ -23509,7 +23554,7 @@
     },
     "serve-static": {
       "version": "1.14.1",
-      "resolved": "https://npm.americanwhitewater.org:443/serve-static/-/serve-static-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "requires": {
         "encodeurl": "~1.0.2",
@@ -23520,13 +23565,13 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/set-value/-/set-value-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
@@ -23538,7 +23583,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -23564,18 +23609,18 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
     "setprototypeof": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://npm.americanwhitewater.org:443/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -23585,7 +23630,7 @@
     },
     "shallow-clone": {
       "version": "3.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "dev": true,
       "requires": {
@@ -23594,7 +23639,7 @@
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
@@ -23603,13 +23648,13 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "shell-quote": {
       "version": "1.7.2",
-      "resolved": "https://npm.americanwhitewater.org:443/shell-quote/-/shell-quote-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
@@ -23626,25 +23671,25 @@
     },
     "shellwords": {
       "version": "0.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/shellwords/-/shellwords-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/sigmund/-/sigmund-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/signal-exit/-/signal-exit-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
     "simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "dev": true,
       "requires": {
@@ -23653,7 +23698,7 @@
       "dependencies": {
         "is-arrayish": {
           "version": "0.3.2",
-          "resolved": "https://npm.americanwhitewater.org:443/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
           "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
           "dev": true
         }
@@ -23661,19 +23706,19 @@
     },
     "sisteransi": {
       "version": "1.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/sisteransi/-/sisteransi-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
     "slash": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/slash/-/slash-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
       "dev": true
     },
     "slice-ansi": {
       "version": "2.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
@@ -23684,7 +23729,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -23705,7 +23750,7 @@
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://npm.americanwhitewater.org:443/snapdragon/-/snapdragon-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
@@ -23721,7 +23766,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://npm.americanwhitewater.org:443/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -23730,7 +23775,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -23739,7 +23784,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://npm.americanwhitewater.org:443/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -23747,7 +23792,7 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
@@ -23758,7 +23803,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -23767,7 +23812,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
@@ -23776,7 +23821,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
@@ -23785,7 +23830,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
@@ -23804,7 +23849,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
@@ -23813,13 +23858,13 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "https://npm.americanwhitewater.org:443/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.americanwhitewater.org:443/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -23830,7 +23875,7 @@
     },
     "sockjs": {
       "version": "0.3.20",
-      "resolved": "https://npm.americanwhitewater.org:443/sockjs/-/sockjs-0.3.20.tgz",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.20.tgz",
       "integrity": "sha512-SpmVOVpdq0DJc0qArhF3E5xsxvaiqGNb73XfgBpK1y3UD5gs8DSo8aCTsuT5pX8rssdc2NDIzANwP9eCAiSdTA==",
       "dev": true,
       "requires": {
@@ -23841,7 +23886,7 @@
     },
     "sockjs-client": {
       "version": "1.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/sockjs-client/-/sockjs-client-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
       "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
       "dev": true,
       "requires": {
@@ -23855,7 +23900,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://npm.americanwhitewater.org:443/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
@@ -23864,7 +23909,7 @@
         },
         "faye-websocket": {
           "version": "0.11.3",
-          "resolved": "https://npm.americanwhitewater.org:443/faye-websocket/-/faye-websocket-0.11.3.tgz",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
           "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
           "dev": true,
           "requires": {
@@ -23873,7 +23918,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -23881,7 +23926,7 @@
     },
     "sort-keys": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/sort-keys/-/sort-keys-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
@@ -23890,18 +23935,18 @@
     },
     "source-list-map": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/source-list-map/-/source-list-map-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
       "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
       "dev": true
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "https://npm.americanwhitewater.org:443/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
-      "resolved": "https://npm.americanwhitewater.org:443/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "dev": true,
       "requires": {
@@ -23914,7 +23959,7 @@
     },
     "source-map-support": {
       "version": "0.5.19",
-      "resolved": "https://npm.americanwhitewater.org:443/source-map-support/-/source-map-support-0.5.19.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "requires": {
@@ -23924,13 +23969,13 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -23939,12 +23984,12 @@
     },
     "spdx-exceptions": {
       "version": "2.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
       "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -23958,7 +24003,7 @@
     },
     "spdy": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/spdy/-/spdy-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
       "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
       "dev": true,
       "requires": {
@@ -23980,7 +24025,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -23988,7 +24033,7 @@
     },
     "spdy-transport": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/spdy-transport/-/spdy-transport-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
       "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "dev": true,
       "requires": {
@@ -24011,13 +24056,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://npm.americanwhitewater.org:443/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
@@ -24030,13 +24075,13 @@
     },
     "specificity": {
       "version": "0.4.1",
-      "resolved": "https://npm.americanwhitewater.org:443/specificity/-/specificity-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
       "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
       "dev": true
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/split-string/-/split-string-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
@@ -24045,13 +24090,13 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "https://npm.americanwhitewater.org:443/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
@@ -24068,7 +24113,7 @@
     },
     "ssri": {
       "version": "6.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/ssri/-/ssri-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
       "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "dev": true,
       "requires": {
@@ -24077,31 +24122,31 @@
     },
     "stable": {
       "version": "0.1.8",
-      "resolved": "https://npm.americanwhitewater.org:443/stable/-/stable-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
     },
     "stack-utils": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/stack-utils/-/stack-utils-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
     },
     "stackframe": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/stackframe/-/stackframe-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
       "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
       "dev": true
     },
     "state-toggle": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/state-toggle/-/state-toggle-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
       "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
       "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -24111,7 +24156,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://npm.americanwhitewater.org:443/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -24122,12 +24167,12 @@
     },
     "statuses": {
       "version": "1.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/statuses/-/statuses-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stdout-stream": {
       "version": "1.4.1",
-      "resolved": "https://npm.americanwhitewater.org:443/stdout-stream/-/stdout-stream-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
       "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
       "dev": true,
       "requires": {
@@ -24136,13 +24181,13 @@
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
     "stream-browserify": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "dev": true,
       "requires": {
@@ -24152,7 +24197,7 @@
     },
     "stream-each": {
       "version": "1.2.3",
-      "resolved": "https://npm.americanwhitewater.org:443/stream-each/-/stream-each-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "dev": true,
       "requires": {
@@ -24162,7 +24207,7 @@
     },
     "stream-http": {
       "version": "2.8.3",
-      "resolved": "https://npm.americanwhitewater.org:443/stream-http/-/stream-http-2.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
@@ -24175,31 +24220,31 @@
     },
     "stream-shift": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/stream-shift/-/stream-shift-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
     "streamsearch": {
       "version": "0.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/streamsearch/-/streamsearch-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
       "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
     "string-argv": {
       "version": "0.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/string-argv/-/string-argv-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
       "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
       "dev": true
     },
     "string-length": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/string-length/-/string-length-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
@@ -24209,7 +24254,7 @@
       "dependencies": {
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -24220,7 +24265,7 @@
     },
     "string-width": {
       "version": "2.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
@@ -24229,7 +24274,7 @@
       "dependencies": {
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -24299,7 +24344,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -24318,7 +24363,7 @@
     },
     "stringify-object": {
       "version": "3.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/stringify-object/-/stringify-object-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
       "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
       "dev": true,
       "requires": {
@@ -24329,17 +24374,17 @@
     },
     "strip-ansi": {
       "version": "0.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
       "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-comments": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/strip-comments/-/strip-comments-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
       "integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
       "dev": true,
       "requires": {
@@ -24349,37 +24394,37 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
     "strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
     "strip-indent": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/strip-indent/-/strip-indent-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "style-search": {
       "version": "0.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/style-search/-/style-search-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
       "dev": true
     },
     "stylehacks": {
       "version": "4.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/stylehacks/-/stylehacks-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
       "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
       "dev": true,
       "requires": {
@@ -24438,7 +24483,7 @@
         },
         "postcss-selector-parser": {
           "version": "3.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
           "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
           "dev": true,
           "requires": {
@@ -24516,13 +24561,13 @@
       "dependencies": {
         "@nodelib/fs.stat": {
           "version": "2.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/@nodelib%2ffs.stat/-/fs.stat-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
           "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
           "dev": true
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
@@ -24537,7 +24582,7 @@
         },
         "array-union": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/array-union/-/array-union-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
           "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
           "dev": true
         },
@@ -24549,7 +24594,7 @@
         },
         "braces": {
           "version": "3.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/braces/-/braces-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
           "requires": {
@@ -24564,7 +24609,7 @@
         },
         "camelcase-keys": {
           "version": "6.2.2",
-          "resolved": "https://npm.americanwhitewater.org:443/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
           "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
           "dev": true,
           "requires": {
@@ -24575,7 +24620,7 @@
         },
         "chalk": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
@@ -24585,7 +24630,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -24616,7 +24661,7 @@
         },
         "dir-glob": {
           "version": "3.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/dir-glob/-/dir-glob-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
           "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
           "dev": true,
           "requires": {
@@ -24631,7 +24676,7 @@
         },
         "fast-glob": {
           "version": "3.2.4",
-          "resolved": "https://npm.americanwhitewater.org:443/fast-glob/-/fast-glob-3.2.4.tgz",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
           "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
           "dev": true,
           "requires": {
@@ -24645,7 +24690,7 @@
         },
         "fill-range": {
           "version": "7.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/fill-range/-/fill-range-7.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
@@ -24654,7 +24699,7 @@
         },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/find-up/-/find-up-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
@@ -24664,13 +24709,13 @@
         },
         "get-stdin": {
           "version": "8.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/get-stdin/-/get-stdin-8.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
           "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
           "dev": true
         },
         "globby": {
           "version": "11.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/globby/-/globby-11.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
           "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
           "dev": true,
           "requires": {
@@ -24684,13 +24729,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "ignore": {
           "version": "5.1.8",
-          "resolved": "https://npm.americanwhitewater.org:443/ignore/-/ignore-5.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
           "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
           "dev": true
         },
@@ -24706,7 +24751,7 @@
           "dependencies": {
             "resolve-from": {
               "version": "4.0.0",
-              "resolved": "https://npm.americanwhitewater.org:443/resolve-from/-/resolve-from-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
               "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
               "dev": true
             }
@@ -24714,19 +24759,19 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "is-number": {
           "version": "7.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-number/-/is-number-7.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/locate-path/-/locate-path-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
@@ -24735,7 +24780,7 @@
         },
         "log-symbols": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/log-symbols/-/log-symbols-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
           "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
           "dev": true,
           "requires": {
@@ -24744,7 +24789,7 @@
         },
         "map-obj": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/map-obj/-/map-obj-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
           "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
           "dev": true
         },
@@ -24769,7 +24814,7 @@
         },
         "micromatch": {
           "version": "4.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/micromatch/-/micromatch-4.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
           "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
           "dev": true,
           "requires": {
@@ -24779,7 +24824,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
@@ -24794,7 +24839,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/p-locate/-/p-locate-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
@@ -24821,13 +24866,13 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/path-exists/-/path-exists-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
         "path-type": {
           "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/path-type/-/path-type-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         },
@@ -24927,7 +24972,7 @@
         },
         "read-pkg-up": {
           "version": "7.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
           "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
           "dev": true,
           "requires": {
@@ -24938,7 +24983,7 @@
           "dependencies": {
             "type-fest": {
               "version": "0.8.1",
-              "resolved": "https://npm.americanwhitewater.org:443/type-fest/-/type-fest-0.8.1.tgz",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
               "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
               "dev": true
             }
@@ -24946,7 +24991,7 @@
         },
         "redent": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/redent/-/redent-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
           "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
           "dev": true,
           "requires": {
@@ -24956,13 +25001,13 @@
         },
         "resolve-from": {
           "version": "5.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/resolve-from/-/resolve-from-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
         },
         "slash": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/slash/-/slash-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
         },
@@ -24979,7 +25024,7 @@
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
@@ -24990,7 +25035,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -24999,7 +25044,7 @@
         },
         "strip-indent": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-indent/-/strip-indent-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
           "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
           "dev": true,
           "requires": {
@@ -25029,7 +25074,7 @@
         },
         "to-regex-range": {
           "version": "5.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
@@ -25038,19 +25083,19 @@
         },
         "trim-newlines": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/trim-newlines/-/trim-newlines-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
           "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
           "dev": true
         },
         "type-fest": {
           "version": "0.13.1",
-          "resolved": "https://npm.americanwhitewater.org:443/type-fest/-/type-fest-0.13.1.tgz",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
           "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
           "dev": true
         },
         "write-file-atomic": {
           "version": "3.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
           "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
           "dev": true,
           "requires": {
@@ -25062,7 +25107,7 @@
         },
         "yargs-parser": {
           "version": "18.1.3",
-          "resolved": "https://npm.americanwhitewater.org:443/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
           "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
@@ -25074,7 +25119,7 @@
     },
     "stylelint-order": {
       "version": "4.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/stylelint-order/-/stylelint-order-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-4.1.0.tgz",
       "integrity": "sha512-sVTikaDvMqg2aJjh4r48jsdfmqLT+nqB1MOsaBnvM3OwLx4S+WXcsxsgk5w18h/OZoxZCxuyXMh61iBHcj9Qiw==",
       "dev": true,
       "requires": {
@@ -25144,7 +25189,7 @@
     },
     "stylelint-scss": {
       "version": "3.18.0",
-      "resolved": "https://npm.americanwhitewater.org:443/stylelint-scss/-/stylelint-scss-3.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.18.0.tgz",
       "integrity": "sha512-LD7+hv/6/ApNGt7+nR/50ft7cezKP2HM5rI8avIdGaUWre3xlHfV4jKO/DRZhscfuN+Ewy9FMhcTq0CcS0C/SA==",
       "dev": true,
       "requires": {
@@ -25170,7 +25215,7 @@
       "dependencies": {
         "eventemitter3": {
           "version": "3.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
           "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
           "dev": true
         },
@@ -25184,7 +25229,7 @@
     },
     "sugarss": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/sugarss/-/sugarss-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
       "integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
       "dev": true,
       "requires": {
@@ -25252,7 +25297,7 @@
     },
     "supercluster": {
       "version": "7.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/supercluster/-/supercluster-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.0.tgz",
       "integrity": "sha512-LDasImUAFMhTqhK+cUXfy9C2KTUqJ3gucLjmNLNFmKWOnDUBxLFLH9oKuXOTCLveecmxh8fbk8kgh6Q0gsfe2w==",
       "requires": {
         "kdbush": "^3.0.0"
@@ -25260,7 +25305,7 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/supports-color/-/supports-color-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
@@ -25295,13 +25340,13 @@
     },
     "svg-tags": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/svg-tags/-/svg-tags-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
     },
     "svgo": {
       "version": "1.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/svgo/-/svgo-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
       "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
       "dev": true,
       "requires": {
@@ -25322,7 +25367,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -25331,7 +25376,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -25355,13 +25400,13 @@
     },
     "symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
     "table": {
       "version": "5.4.6",
-      "resolved": "https://npm.americanwhitewater.org:443/table/-/table-5.4.6.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
       "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
@@ -25373,19 +25418,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
@@ -25396,7 +25441,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -25407,13 +25452,13 @@
     },
     "tapable": {
       "version": "1.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/tapable/-/tapable-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
     },
     "tar": {
       "version": "2.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/tar/-/tar-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
       "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
@@ -25424,7 +25469,7 @@
     },
     "term-size": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/term-size/-/term-size-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
@@ -25433,7 +25478,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
@@ -25444,7 +25489,7 @@
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "https://npm.americanwhitewater.org:443/execa/-/execa-0.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
@@ -25459,13 +25504,13 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/lru-cache/-/lru-cache-4.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
@@ -25475,7 +25520,7 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -25483,7 +25528,7 @@
     },
     "terser": {
       "version": "4.8.0",
-      "resolved": "https://npm.americanwhitewater.org:443/terser/-/terser-4.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
       "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
       "dev": true,
       "requires": {
@@ -25511,7 +25556,7 @@
       "dependencies": {
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/schema-utils/-/schema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
@@ -25524,7 +25569,7 @@
     },
     "test-exclude": {
       "version": "5.2.3",
-      "resolved": "https://npm.americanwhitewater.org:443/test-exclude/-/test-exclude-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
       "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
       "dev": true,
       "requires": {
@@ -25639,13 +25684,13 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "thenify": {
       "version": "3.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/thenify/-/thenify-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dev": true,
       "requires": {
@@ -25654,7 +25699,7 @@
     },
     "thenify-all": {
       "version": "1.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/thenify-all/-/thenify-all-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
@@ -25663,7 +25708,7 @@
     },
     "thread-loader": {
       "version": "2.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/thread-loader/-/thread-loader-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
       "integrity": "sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==",
       "dev": true,
       "requires": {
@@ -25674,7 +25719,7 @@
     },
     "throat": {
       "version": "4.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/throat/-/throat-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
@@ -25686,13 +25731,13 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://npm.americanwhitewater.org:443/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/through2/-/through2-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
@@ -25702,13 +25747,13 @@
     },
     "thunky": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/thunky/-/thunky-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
     "timed-out": {
       "version": "4.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/timed-out/-/timed-out-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
@@ -25723,13 +25768,13 @@
     },
     "timsort": {
       "version": "0.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/timsort/-/timsort-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
     "tinyqueue": {
       "version": "2.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
     },
     "tiptap": {
@@ -25796,7 +25841,7 @@
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "https://npm.americanwhitewater.org:443/tmp/-/tmp-0.0.33.tgz",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
@@ -25805,25 +25850,25 @@
     },
     "tmpl": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/tmpl/-/tmpl-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -25832,13 +25877,13 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "https://npm.americanwhitewater.org:443/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.americanwhitewater.org:443/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -25849,7 +25894,7 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/to-regex/-/to-regex-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
@@ -25861,7 +25906,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
@@ -25871,18 +25916,18 @@
     },
     "toidentifier": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/toidentifier/-/toidentifier-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "toposort": {
       "version": "1.0.7",
-      "resolved": "https://npm.americanwhitewater.org:443/toposort/-/toposort-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
       "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
       "dev": true
     },
     "touch": {
       "version": "3.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/touch/-/touch-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
       "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
       "dev": true,
       "requires": {
@@ -25891,7 +25936,7 @@
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "resolved": "https://npm.americanwhitewater.org:443/nopt/-/nopt-1.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true,
           "requires": {
@@ -25902,7 +25947,7 @@
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
@@ -25912,7 +25957,7 @@
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/tr46/-/tr46-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
@@ -25921,24 +25966,24 @@
     },
     "traverse": {
       "version": "0.6.6",
-      "resolved": "https://npm.americanwhitewater.org:443/traverse/-/traverse-0.6.6.tgz",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "treeify": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/treeify/-/treeify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
       "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
       "dev": true
     },
     "trim": {
       "version": "0.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/trim/-/trim-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
       "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
@@ -25950,13 +25995,13 @@
     },
     "trough": {
       "version": "1.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/trough/-/trough-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
     },
     "true-case-path": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/true-case-path/-/true-case-path-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
       "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
       "dev": true,
       "requires": {
@@ -25965,13 +26010,13 @@
     },
     "tryer": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/tryer/-/tryer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
       "dev": true
     },
     "ts-invariant": {
       "version": "0.4.4",
-      "resolved": "https://npm.americanwhitewater.org:443/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
       "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
       "requires": {
         "tslib": "^1.9.3"
@@ -25979,7 +26024,7 @@
     },
     "ts-jest": {
       "version": "24.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/ts-jest/-/ts-jest-24.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.3.0.tgz",
       "integrity": "sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==",
       "dev": true,
       "requires": {
@@ -25997,7 +26042,7 @@
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
@@ -26018,7 +26063,7 @@
         },
         "yargs-parser": {
           "version": "10.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
@@ -26029,7 +26074,7 @@
     },
     "ts-node": {
       "version": "8.10.2",
-      "resolved": "https://npm.americanwhitewater.org:443/ts-node/-/ts-node-8.10.2.tgz",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
       "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
       "dev": true,
       "requires": {
@@ -26042,13 +26087,13 @@
     },
     "ts-pnp": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/ts-pnp/-/ts-pnp-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
       "dev": true
     },
     "tsconfig": {
       "version": "7.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/tsconfig/-/tsconfig-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
       "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
       "dev": true,
       "requires": {
@@ -26060,7 +26105,7 @@
     },
     "tsconfig-paths": {
       "version": "3.9.0",
-      "resolved": "https://npm.americanwhitewater.org:443/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
       "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
       "requires": {
         "@types/json5": "^0.0.29",
@@ -26085,19 +26130,19 @@
     },
     "tty": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/tty/-/tty-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tty/-/tty-1.0.1.tgz",
       "integrity": "sha1-5ECayYsN0cULWf846G6sPwdk7kU=",
       "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
@@ -26106,18 +26151,18 @@
     },
     "turf-jsts": {
       "version": "1.2.3",
-      "resolved": "https://npm.americanwhitewater.org:443/turf-jsts/-/turf-jsts-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
       "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://npm.americanwhitewater.org:443/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -26126,13 +26171,13 @@
     },
     "type-fest": {
       "version": "0.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/type-fest/-/type-fest-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true
     },
     "type-is": {
       "version": "1.6.18",
-      "resolved": "https://npm.americanwhitewater.org:443/type-is/-/type-is-1.6.18.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "requires": {
         "media-typer": "0.3.0",
@@ -26141,12 +26186,12 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
-      "resolved": "https://npm.americanwhitewater.org:443/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
       "requires": {
@@ -26160,7 +26205,7 @@
     },
     "uglify-js": {
       "version": "3.4.10",
-      "resolved": "https://npm.americanwhitewater.org:443/uglify-js/-/uglify-js-3.4.10.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
       "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
       "dev": true,
       "requires": {
@@ -26170,7 +26215,7 @@
       "dependencies": {
         "commander": {
           "version": "2.19.0",
-          "resolved": "https://npm.americanwhitewater.org:443/commander/-/commander-2.19.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
           "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
           "dev": true
         }
@@ -26178,7 +26223,7 @@
     },
     "undefsafe": {
       "version": "2.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/undefsafe/-/undefsafe-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.3.tgz",
       "integrity": "sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==",
       "dev": true,
       "requires": {
@@ -26187,12 +26232,12 @@
     },
     "underscore": {
       "version": "1.6.0",
-      "resolved": "https://npm.americanwhitewater.org:443/underscore/-/underscore-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
     },
     "unherit": {
       "version": "1.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/unherit/-/unherit-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
       "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
       "dev": true,
       "requires": {
@@ -26202,13 +26247,13 @@
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
       "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
       "dev": true
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
       "requires": {
@@ -26218,13 +26263,13 @@
     },
     "unicode-match-property-value-ecmascript": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
       "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
       "dev": true
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
       "dev": true
     },
@@ -26244,7 +26289,7 @@
       "dependencies": {
         "is-plain-obj": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
           "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
           "dev": true
         }
@@ -26252,7 +26297,7 @@
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/union-value/-/union-value-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
@@ -26264,19 +26309,19 @@
     },
     "uniq": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/uniq/-/uniq-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "uniqs": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/uniqs/-/uniqs-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
     "unique-filename": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/unique-filename/-/unique-filename-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "requires": {
@@ -26285,7 +26330,7 @@
     },
     "unique-slug": {
       "version": "2.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/unique-slug/-/unique-slug-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "dev": true,
       "requires": {
@@ -26294,7 +26339,7 @@
     },
     "unique-string": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/unique-string/-/unique-string-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
@@ -26318,7 +26363,7 @@
     },
     "unist-util-remove-position": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/unist-util-remove-position/-/unist-util-remove-position-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-2.0.1.tgz",
       "integrity": "sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==",
       "dev": true,
       "requires": {
@@ -26327,7 +26372,7 @@
     },
     "unist-util-stringify-position": {
       "version": "2.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
       "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
       "requires": {
         "@types/unist": "^2.0.2"
@@ -26356,24 +26401,24 @@
     },
     "universalify": {
       "version": "0.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/universalify/-/universalify-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unquote": {
       "version": "1.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/unquote/-/unquote-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
       "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
       "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -26383,7 +26428,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://npm.americanwhitewater.org:443/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -26394,7 +26439,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://npm.americanwhitewater.org:443/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -26405,7 +26450,7 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://npm.americanwhitewater.org:443/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         },
@@ -26419,19 +26464,19 @@
     },
     "unzip-response": {
       "version": "2.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/unzip-response/-/unzip-response-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
       "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
       "dev": true
     },
     "upath": {
       "version": "1.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/upath/-/upath-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
       "dev": true
     },
     "update-notifier": {
       "version": "2.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/update-notifier/-/update-notifier-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "requires": {
@@ -26449,7 +26494,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -26458,7 +26503,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -26475,7 +26520,7 @@
         },
         "import-lazy": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/import-lazy/-/import-lazy-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
           "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
           "dev": true
         }
@@ -26483,7 +26528,7 @@
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
@@ -26507,13 +26552,13 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://npm.americanwhitewater.org:443/url/-/url-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "requires": {
@@ -26523,7 +26568,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://npm.americanwhitewater.org:443/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -26531,7 +26576,7 @@
     },
     "url-loader": {
       "version": "2.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/url-loader/-/url-loader-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-2.3.0.tgz",
       "integrity": "sha512-goSdg8VY+7nPZKUEChZSEtW5gjbS66USIGCeSJ1OVOJ7Yfuh/36YxCwMi5HVEJh6mqUYOoy3NJ0vlOMrWsSHog==",
       "dev": true,
       "requires": {
@@ -26542,7 +26587,7 @@
       "dependencies": {
         "mime": {
           "version": "2.4.6",
-          "resolved": "https://npm.americanwhitewater.org:443/mime/-/mime-2.4.6.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
           "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
           "dev": true
         }
@@ -26550,7 +26595,7 @@
     },
     "url-parse": {
       "version": "1.4.7",
-      "resolved": "https://npm.americanwhitewater.org:443/url-parse/-/url-parse-1.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "dev": true,
       "requires": {
@@ -26560,7 +26605,7 @@
     },
     "url-parse-lax": {
       "version": "1.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
@@ -26569,13 +26614,13 @@
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/use/-/use-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
     "util": {
       "version": "0.11.1",
-      "resolved": "https://npm.americanwhitewater.org:443/util/-/util-0.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
       "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
       "dev": true,
       "requires": {
@@ -26584,7 +26629,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         }
@@ -26592,12 +26637,12 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/util.promisify/-/util.promisify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
       "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
       "dev": true,
       "requires": {
@@ -26609,18 +26654,18 @@
     },
     "utila": {
       "version": "0.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/utila/-/utila-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/uuid/-/uuid-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
@@ -26632,7 +26677,7 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -26641,18 +26686,18 @@
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vendors": {
       "version": "1.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/vendors/-/vendors-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
       "integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==",
       "dev": true
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://npm.americanwhitewater.org:443/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -26681,7 +26726,7 @@
     },
     "vfile-message": {
       "version": "2.0.4",
-      "resolved": "https://npm.americanwhitewater.org:443/vfile-message/-/vfile-message-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
       "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
       "requires": {
         "@types/unist": "^2.0.0",
@@ -26690,7 +26735,7 @@
     },
     "vfile-reporter": {
       "version": "5.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/vfile-reporter/-/vfile-reporter-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-5.1.2.tgz",
       "integrity": "sha512-b15sTuss1wOPWVlyWOvu+n6wGJ/eTYngz3uqMLimQvxZ+Q5oFQGYZZP1o3dR9sk58G5+wej0UPCZSwQBX/mzrQ==",
       "requires": {
         "repeat-string": "^1.5.0",
@@ -26703,29 +26748,29 @@
     },
     "vfile-sort": {
       "version": "2.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/vfile-sort/-/vfile-sort-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.2.2.tgz",
       "integrity": "sha512-tAyUqD2R1l/7Rn7ixdGkhXLD3zsg+XLAeUDUhXearjfIcpL1Hcsj5hHpCoy/gvfK/Ws61+e972fm0F7up7hfYA=="
     },
     "vfile-statistics": {
       "version": "1.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/vfile-statistics/-/vfile-statistics-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.4.tgz",
       "integrity": "sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA=="
     },
     "vm-browserify": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
     },
     "vscode-jsonrpc": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
       "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
       "dev": true
     },
     "vscode-languageserver": {
       "version": "5.2.1",
-      "resolved": "https://npm.americanwhitewater.org:443/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz",
       "integrity": "sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==",
       "dev": true,
       "requires": {
@@ -26735,7 +26780,7 @@
     },
     "vscode-languageserver-protocol": {
       "version": "3.14.1",
-      "resolved": "https://npm.americanwhitewater.org:443/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
       "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
       "dev": true,
       "requires": {
@@ -26745,19 +26790,19 @@
     },
     "vscode-languageserver-types": {
       "version": "3.14.0",
-      "resolved": "https://npm.americanwhitewater.org:443/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
       "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==",
       "dev": true
     },
     "vscode-uri": {
       "version": "1.0.6",
-      "resolved": "https://npm.americanwhitewater.org:443/vscode-uri/-/vscode-uri-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
       "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==",
       "dev": true
     },
     "vt-pbf": {
       "version": "3.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/vt-pbf/-/vt-pbf-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.1.tgz",
       "integrity": "sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==",
       "requires": {
         "@mapbox/point-geometry": "0.1.0",
@@ -26783,7 +26828,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -26792,7 +26837,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -26811,12 +26856,12 @@
     },
     "vue-check-view": {
       "version": "0.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/vue-check-view/-/vue-check-view-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/vue-check-view/-/vue-check-view-0.3.0.tgz",
       "integrity": "sha512-2IR2m4MCgOG/9UQaIn7cvvqbDcvUmPavun8nBMieRxGbhqvlUorjLIwJqvuFXruBO73HXXbCcrVKxnGr4ub5ag=="
     },
     "vue-cli-plugin-apollo": {
       "version": "0.21.3",
-      "resolved": "https://npm.americanwhitewater.org:443/vue-cli-plugin-apollo/-/vue-cli-plugin-apollo-0.21.3.tgz",
+      "resolved": "https://registry.npmjs.org/vue-cli-plugin-apollo/-/vue-cli-plugin-apollo-0.21.3.tgz",
       "integrity": "sha512-8CzRVrAsFkB9lpl600cRCNR9OUnrSYYAIVF9/qW4pP0TMXbhrd1F1wEAAN6E0CPimjTLB+qSt6zWS4vb2wC8Wg==",
       "dev": true,
       "requires": {
@@ -26851,7 +26896,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -26860,7 +26905,7 @@
         },
         "apollo-upload-client": {
           "version": "11.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/apollo-upload-client/-/apollo-upload-client-11.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-11.0.0.tgz",
           "integrity": "sha512-JChTrBi1VSF8u6OPrkWUApJlyUvzwhw98kqRB3fSi7/CU6z0OUD42Mee9s5h8mfjKEfOanK6GNZhF4t2tIPXSw==",
           "dev": true,
           "requires": {
@@ -26872,7 +26917,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -26883,7 +26928,7 @@
         },
         "cross-spawn": {
           "version": "7.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
           "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
@@ -26900,7 +26945,7 @@
         },
         "execa": {
           "version": "3.4.0",
-          "resolved": "https://npm.americanwhitewater.org:443/execa/-/execa-3.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
           "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
           "dev": true,
           "requires": {
@@ -26918,7 +26963,7 @@
         },
         "fs-extra": {
           "version": "8.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/fs-extra/-/fs-extra-8.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
@@ -26947,19 +26992,19 @@
         },
         "is-stream": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/is-stream/-/is-stream-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
           "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "npm-run-path": {
           "version": "4.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
           "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
           "dev": true,
           "requires": {
@@ -26977,19 +27022,19 @@
         },
         "p-finally": {
           "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/p-finally/-/p-finally-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
           "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
           "dev": true
         },
         "path-key": {
           "version": "3.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/path-key/-/path-key-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
         "shebang-command": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/shebang-command/-/shebang-command-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
@@ -26998,13 +27043,13 @@
         },
         "shebang-regex": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
         "which": {
           "version": "2.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/which/-/which-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
@@ -27048,7 +27093,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -27061,7 +27106,7 @@
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",
-      "resolved": "https://npm.americanwhitewater.org:443/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
     },
@@ -27086,7 +27131,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -27095,7 +27140,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -27112,7 +27157,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://npm.americanwhitewater.org:443/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -27133,106 +27178,15 @@
       "dependencies": {
         "hash-sum": {
           "version": "1.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/hash-sum/-/hash-sum-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
         }
       }
     },
-    "vue-loader-v16": {
-      "version": "npm:vue-loader@16.0.0-rc.1",
-      "resolved": "https://npm.americanwhitewater.org:443/vue-loader/-/vue-loader-16.0.0-rc.1.tgz",
-      "integrity": "sha512-yR+BS90EOXTNieasf8ce9J3TFCpm2DGqoqdbtiwQ33hon3FyIznLX7sKavAq1VmfBnOeV6It0Htg4aniv8ph1g==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "hash-sum": "^2.0.0",
-        "loader-utils": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "json5": {
-          "version": "2.1.3",
-          "resolved": "https://npm.americanwhitewater.org:443/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://npm.americanwhitewater.org:443/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true,
-          "optional": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "vue-meta": {
       "version": "2.4.0",
-      "resolved": "https://npm.americanwhitewater.org:443/vue-meta/-/vue-meta-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/vue-meta/-/vue-meta-2.4.0.tgz",
       "integrity": "sha512-XEeZUmlVeODclAjCNpWDnjgw+t3WA6gdzs6ENoIAgwO1J1d5p1tezDhtteLUFwcaQaTtayRrsx7GL6oXp/m2Jw==",
       "requires": {
         "deepmerge": "^4.2.2"
@@ -27253,7 +27207,7 @@
     },
     "vue-social-sharing": {
       "version": "2.4.7",
-      "resolved": "https://npm.americanwhitewater.org:443/vue-social-sharing/-/vue-social-sharing-2.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/vue-social-sharing/-/vue-social-sharing-2.4.7.tgz",
       "integrity": "sha512-X70bulEnjSHvakf8NaLhuKTuUS4yKzdhYjX/aJ4dPVIXWaoXH8w+QODuM3C6c3fPaiNqgR19VrDyWB7EUGUzPQ==",
       "requires": {
         "vue": "^2.2.4"
@@ -27261,7 +27215,7 @@
     },
     "vue-style-loader": {
       "version": "4.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/vue-style-loader/-/vue-style-loader-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",
       "integrity": "sha512-0ip8ge6Gzz/Bk0iHovU9XAUQaFt/G2B61bnWa2tCcqqdgfHs1lF9xXorFbE55Gmy92okFT+8bfmySuUOu13vxQ==",
       "dev": true,
       "requires": {
@@ -27271,7 +27225,7 @@
       "dependencies": {
         "hash-sum": {
           "version": "1.0.2",
-          "resolved": "https://npm.americanwhitewater.org:443/hash-sum/-/hash-sum-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
         }
@@ -27289,18 +27243,18 @@
     },
     "vue-template-es2015-compiler": {
       "version": "1.9.1",
-      "resolved": "https://npm.americanwhitewater.org:443/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
     },
     "vuex": {
       "version": "3.5.1",
-      "resolved": "https://npm.americanwhitewater.org:443/vuex/-/vuex-3.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.5.1.tgz",
       "integrity": "sha512-w7oJzmHQs0FM9LXodfskhw9wgKBiaB+totOdb8sNzbTB2KDCEEwEs29NzBZFh/lmEK1t5tDmM1vtsO7ubG1DFw=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
       "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
       "dev": true,
       "requires": {
@@ -27309,12 +27263,12 @@
     },
     "w3c-keyname": {
       "version": "2.2.4",
-      "resolved": "https://npm.americanwhitewater.org:443/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
       "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
     },
     "w3c-xmlserializer": {
       "version": "1.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
       "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
       "dev": true,
       "requires": {
@@ -27325,7 +27279,7 @@
     },
     "walker": {
       "version": "1.0.7",
-      "resolved": "https://npm.americanwhitewater.org:443/walker/-/walker-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
@@ -27334,7 +27288,7 @@
     },
     "warning": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/warning/-/warning-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "requires": {
         "loose-envify": "^1.0.0"
@@ -27354,7 +27308,7 @@
     },
     "watchpack-chokidar2": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
       "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
       "dev": true,
       "optional": true,
@@ -27364,7 +27318,7 @@
       "dependencies": {
         "anymatch": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/anymatch/-/anymatch-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "optional": true,
@@ -27375,7 +27329,7 @@
           "dependencies": {
             "normalize-path": {
               "version": "2.1.1",
-              "resolved": "https://npm.americanwhitewater.org:443/normalize-path/-/normalize-path-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
               "dev": true,
               "optional": true,
@@ -27387,14 +27341,14 @@
         },
         "binary-extensions": {
           "version": "1.13.1",
-          "resolved": "https://npm.americanwhitewater.org:443/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
           "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
           "dev": true,
           "optional": true
         },
         "chokidar": {
           "version": "2.1.8",
-          "resolved": "https://npm.americanwhitewater.org:443/chokidar/-/chokidar-2.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
           "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
           "dev": true,
           "optional": true,
@@ -27415,7 +27369,7 @@
         },
         "fsevents": {
           "version": "1.2.13",
-          "resolved": "https://npm.americanwhitewater.org:443/fsevents/-/fsevents-1.2.13.tgz",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
           "optional": true,
@@ -27426,7 +27380,7 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "optional": true,
@@ -27437,7 +27391,7 @@
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
-              "resolved": "https://npm.americanwhitewater.org:443/is-glob/-/is-glob-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "optional": true,
@@ -27449,7 +27403,7 @@
         },
         "is-binary-path": {
           "version": "1.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "dev": true,
           "optional": true,
@@ -27459,7 +27413,7 @@
         },
         "readdirp": {
           "version": "2.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/readdirp/-/readdirp-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
           "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
           "dev": true,
           "optional": true,
@@ -27473,7 +27427,7 @@
     },
     "wbuf": {
       "version": "1.7.3",
-      "resolved": "https://npm.americanwhitewater.org:443/wbuf/-/wbuf-1.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "requires": {
@@ -27482,7 +27436,7 @@
     },
     "wcwidth": {
       "version": "1.0.1",
-      "resolved": "https://npm.americanwhitewater.org:443/wcwidth/-/wcwidth-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
@@ -27491,7 +27445,7 @@
     },
     "webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
     },
@@ -27528,7 +27482,7 @@
       "dependencies": {
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/schema-utils/-/schema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
@@ -27568,13 +27522,13 @@
         },
         "acorn-walk": {
           "version": "7.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/acorn-walk/-/acorn-walk-7.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
           "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -27583,7 +27537,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://npm.americanwhitewater.org:443/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -27600,7 +27554,7 @@
         },
         "ws": {
           "version": "6.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ws/-/ws-6.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
           "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "dev": true,
           "requires": {
@@ -27621,7 +27575,7 @@
       "dependencies": {
         "deepmerge": {
           "version": "1.5.2",
-          "resolved": "https://npm.americanwhitewater.org:443/deepmerge/-/deepmerge-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
           "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==",
           "dev": true
         }
@@ -27629,7 +27583,7 @@
     },
     "webpack-dev-middleware": {
       "version": "3.7.2",
-      "resolved": "https://npm.americanwhitewater.org:443/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
       "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
       "dev": true,
       "requires": {
@@ -27642,7 +27596,7 @@
       "dependencies": {
         "mime": {
           "version": "2.4.6",
-          "resolved": "https://npm.americanwhitewater.org:443/mime/-/mime-2.4.6.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
           "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
           "dev": true
         }
@@ -27650,7 +27604,7 @@
     },
     "webpack-dev-server": {
       "version": "3.11.0",
-      "resolved": "https://npm.americanwhitewater.org:443/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz",
       "integrity": "sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==",
       "dev": true,
       "requires": {
@@ -27691,13 +27645,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "anymatch": {
           "version": "2.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/anymatch/-/anymatch-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
@@ -27707,7 +27661,7 @@
           "dependencies": {
             "normalize-path": {
               "version": "2.1.1",
-              "resolved": "https://npm.americanwhitewater.org:443/normalize-path/-/normalize-path-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
               "dev": true,
               "requires": {
@@ -27718,13 +27672,13 @@
         },
         "binary-extensions": {
           "version": "1.13.1",
-          "resolved": "https://npm.americanwhitewater.org:443/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
           "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
           "dev": true
         },
         "chokidar": {
           "version": "2.1.8",
-          "resolved": "https://npm.americanwhitewater.org:443/chokidar/-/chokidar-2.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
           "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
           "dev": true,
           "requires": {
@@ -27753,7 +27707,7 @@
         },
         "fsevents": {
           "version": "1.2.13",
-          "resolved": "https://npm.americanwhitewater.org:443/fsevents/-/fsevents-1.2.13.tgz",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
           "optional": true,
@@ -27764,7 +27718,7 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -27774,7 +27728,7 @@
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
-              "resolved": "https://npm.americanwhitewater.org:443/is-glob/-/is-glob-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
@@ -27785,13 +27739,13 @@
         },
         "is-absolute-url": {
           "version": "3.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
           "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
           "dev": true
         },
         "is-binary-path": {
           "version": "1.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "dev": true,
           "requires": {
@@ -27800,13 +27754,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "readdirp": {
           "version": "2.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/readdirp/-/readdirp-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
           "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
           "dev": true,
           "requires": {
@@ -27817,7 +27771,7 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/schema-utils/-/schema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
@@ -27828,13 +27782,13 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://npm.americanwhitewater.org:443/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -27843,7 +27797,7 @@
         },
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/supports-color/-/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
@@ -27852,7 +27806,7 @@
         },
         "ws": {
           "version": "6.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ws/-/ws-6.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
           "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "dev": true,
           "requires": {
@@ -27863,7 +27817,7 @@
     },
     "webpack-log": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/webpack-log/-/webpack-log-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
       "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
       "dev": true,
       "requires": {
@@ -27873,7 +27827,7 @@
     },
     "webpack-merge": {
       "version": "4.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
       "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
       "dev": true,
       "requires": {
@@ -27882,7 +27836,7 @@
     },
     "webpack-sources": {
       "version": "1.4.3",
-      "resolved": "https://npm.americanwhitewater.org:443/webpack-sources/-/webpack-sources-1.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
       "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
       "dev": true,
       "requires": {
@@ -27892,7 +27846,7 @@
     },
     "websocket-driver": {
       "version": "0.6.5",
-      "resolved": "https://npm.americanwhitewater.org:443/websocket-driver/-/websocket-driver-0.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
       "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
       "dev": true,
       "requires": {
@@ -27901,18 +27855,18 @@
     },
     "websocket-extensions": {
       "version": "0.1.4",
-      "resolved": "https://npm.americanwhitewater.org:443/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
     "wgs84": {
       "version": "0.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/wgs84/-/wgs84-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
       "integrity": "sha1-NP3FVZF7blfPKigu0ENxDASc3HY="
     },
     "whatwg-encoding": {
       "version": "1.0.5",
-      "resolved": "https://npm.americanwhitewater.org:443/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
       "dev": true,
       "requires": {
@@ -27921,13 +27875,13 @@
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "https://npm.americanwhitewater.org:443/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
       "dev": true
     },
     "whatwg-url": {
       "version": "6.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
@@ -27938,7 +27892,7 @@
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/which/-/which-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
@@ -27947,13 +27901,13 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "wide-align": {
       "version": "1.1.3",
-      "resolved": "https://npm.americanwhitewater.org:443/wide-align/-/wide-align-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
@@ -28005,7 +27959,7 @@
     },
     "wkx": {
       "version": "0.5.0",
-      "resolved": "https://npm.americanwhitewater.org:443/wkx/-/wkx-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
       "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
       "requires": {
         "@types/node": "*"
@@ -28013,13 +27967,13 @@
     },
     "word-wrap": {
       "version": "1.2.3",
-      "resolved": "https://npm.americanwhitewater.org:443/word-wrap/-/word-wrap-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "workbox-background-sync": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-background-sync/-/workbox-background-sync-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-4.3.1.tgz",
       "integrity": "sha512-1uFkvU8JXi7L7fCHVBEEnc3asPpiAL33kO495UMcD5+arew9IbKW2rV5lpzhoWcm/qhGB89YfO4PmB/0hQwPRg==",
       "dev": true,
       "requires": {
@@ -28028,7 +27982,7 @@
     },
     "workbox-broadcast-update": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-broadcast-update/-/workbox-broadcast-update-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-4.3.1.tgz",
       "integrity": "sha512-MTSfgzIljpKLTBPROo4IpKjESD86pPFlZwlvVG32Kb70hW+aob4Jxpblud8EhNb1/L5m43DUM4q7C+W6eQMMbA==",
       "dev": true,
       "requires": {
@@ -28037,7 +27991,7 @@
     },
     "workbox-build": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-build/-/workbox-build-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-4.3.1.tgz",
       "integrity": "sha512-UHdwrN3FrDvicM3AqJS/J07X0KXj67R8Cg0waq1MKEOqzo89ap6zh6LmaLnRAjpB+bDIz+7OlPye9iii9KBnxw==",
       "dev": true,
       "requires": {
@@ -28068,7 +28022,7 @@
     },
     "workbox-cacheable-response": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-cacheable-response/-/workbox-cacheable-response-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-4.3.1.tgz",
       "integrity": "sha512-Rp5qlzm6z8IOvnQNkCdO9qrDgDpoPNguovs0H8C+wswLuPgSzSp9p2afb5maUt9R1uTIwOXrVQMmPfPypv+npw==",
       "dev": true,
       "requires": {
@@ -28077,13 +28031,13 @@
     },
     "workbox-core": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-core/-/workbox-core-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-4.3.1.tgz",
       "integrity": "sha512-I3C9jlLmMKPxAC1t0ExCq+QoAMd0vAAHULEgRZ7kieCdUd919n53WC0AfvokHNwqRhGn+tIIj7vcb5duCjs2Kg==",
       "dev": true
     },
     "workbox-expiration": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-expiration/-/workbox-expiration-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-4.3.1.tgz",
       "integrity": "sha512-vsJLhgQsQouv9m0rpbXubT5jw0jMQdjpkum0uT+d9tTwhXcEZks7qLfQ9dGSaufTD2eimxbUOJfWLbNQpIDMPw==",
       "dev": true,
       "requires": {
@@ -28092,7 +28046,7 @@
     },
     "workbox-google-analytics": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-google-analytics/-/workbox-google-analytics-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-4.3.1.tgz",
       "integrity": "sha512-xzCjAoKuOb55CBSwQrbyWBKqp35yg1vw9ohIlU2wTy06ZrYfJ8rKochb1MSGlnoBfXGWss3UPzxR5QL5guIFdg==",
       "dev": true,
       "requires": {
@@ -28104,7 +28058,7 @@
     },
     "workbox-navigation-preload": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-navigation-preload/-/workbox-navigation-preload-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-4.3.1.tgz",
       "integrity": "sha512-K076n3oFHYp16/C+F8CwrRqD25GitA6Rkd6+qAmLmMv1QHPI2jfDwYqrytOfKfYq42bYtW8Pr21ejZX7GvALOw==",
       "dev": true,
       "requires": {
@@ -28113,7 +28067,7 @@
     },
     "workbox-precaching": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-precaching/-/workbox-precaching-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-4.3.1.tgz",
       "integrity": "sha512-piSg/2csPoIi/vPpp48t1q5JLYjMkmg5gsXBQkh/QYapCdVwwmKlU9mHdmy52KsDGIjVaqEUMFvEzn2LRaigqQ==",
       "dev": true,
       "requires": {
@@ -28122,7 +28076,7 @@
     },
     "workbox-range-requests": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-range-requests/-/workbox-range-requests-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-4.3.1.tgz",
       "integrity": "sha512-S+HhL9+iTFypJZ/yQSl/x2Bf5pWnbXdd3j57xnb0V60FW1LVn9LRZkPtneODklzYuFZv7qK6riZ5BNyc0R0jZA==",
       "dev": true,
       "requires": {
@@ -28131,7 +28085,7 @@
     },
     "workbox-routing": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-routing/-/workbox-routing-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-4.3.1.tgz",
       "integrity": "sha512-FkbtrODA4Imsi0p7TW9u9MXuQ5P4pVs1sWHK4dJMMChVROsbEltuE79fBoIk/BCztvOJ7yUpErMKa4z3uQLX+g==",
       "dev": true,
       "requires": {
@@ -28140,7 +28094,7 @@
     },
     "workbox-strategies": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-strategies/-/workbox-strategies-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-4.3.1.tgz",
       "integrity": "sha512-F/+E57BmVG8dX6dCCopBlkDvvhg/zj6VDs0PigYwSN23L8hseSRwljrceU2WzTvk/+BSYICsWmRq5qHS2UYzhw==",
       "dev": true,
       "requires": {
@@ -28149,7 +28103,7 @@
     },
     "workbox-streams": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-streams/-/workbox-streams-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-4.3.1.tgz",
       "integrity": "sha512-4Kisis1f/y0ihf4l3u/+ndMkJkIT4/6UOacU3A4BwZSAC9pQ9vSvJpIi/WFGQRH/uPXvuVjF5c2RfIPQFSS2uA==",
       "dev": true,
       "requires": {
@@ -28158,13 +28112,13 @@
     },
     "workbox-sw": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-sw/-/workbox-sw-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-4.3.1.tgz",
       "integrity": "sha512-0jXdusCL2uC5gM3yYFT6QMBzKfBr2XTk0g5TPAV4y8IZDyVNDyj1a8uSXy3/XrvkVTmQvLN4O5k3JawGReXr9w==",
       "dev": true
     },
     "workbox-webpack-plugin": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-webpack-plugin/-/workbox-webpack-plugin-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-4.3.1.tgz",
       "integrity": "sha512-gJ9jd8Mb8wHLbRz9ZvGN57IAmknOipD3W4XNE/Lk/4lqs5Htw4WOQgakQy/o/4CoXQlMCYldaqUg+EJ35l9MEQ==",
       "dev": true,
       "requires": {
@@ -28175,7 +28129,7 @@
     },
     "workbox-window": {
       "version": "4.3.1",
-      "resolved": "https://npm.americanwhitewater.org:443/workbox-window/-/workbox-window-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-4.3.1.tgz",
       "integrity": "sha512-C5gWKh6I58w3GeSc0wp2Ne+rqVw8qwcmZnQGpjiek8A2wpbxSJb1FdCoQVO+jDJs35bFgo/WETgl1fqgsxN0Hg==",
       "dev": true,
       "requires": {
@@ -28184,7 +28138,7 @@
     },
     "worker-farm": {
       "version": "1.7.0",
-      "resolved": "https://npm.americanwhitewater.org:443/worker-farm/-/worker-farm-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
       "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "dev": true,
       "requires": {
@@ -28193,7 +28147,7 @@
     },
     "wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://npm.americanwhitewater.org:443/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
@@ -28204,13 +28158,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -28219,13 +28173,13 @@
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
@@ -28236,7 +28190,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -28247,13 +28201,13 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
       "version": "1.0.3",
-      "resolved": "https://npm.americanwhitewater.org:443/write/-/write-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
@@ -28262,7 +28216,7 @@
     },
     "write-file-atomic": {
       "version": "2.4.1",
-      "resolved": "https://npm.americanwhitewater.org:443/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
       "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
       "dev": true,
       "requires": {
@@ -28273,7 +28227,7 @@
     },
     "ws": {
       "version": "5.2.2",
-      "resolved": "https://npm.americanwhitewater.org:443/ws/-/ws-5.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
       "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "dev": true,
       "requires": {
@@ -28282,19 +28236,19 @@
     },
     "xdg-basedir": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
     "xmlchars": {
       "version": "2.2.0",
-      "resolved": "https://npm.americanwhitewater.org:443/xmlchars/-/xmlchars-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
@@ -28310,30 +28264,30 @@
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "https://npm.americanwhitewater.org:443/xtend/-/xtend-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/y18n/-/y18n-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {
       "version": "3.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/yallist/-/yallist-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yaml": {
       "version": "1.10.0",
-      "resolved": "https://npm.americanwhitewater.org:443/yaml/-/yaml-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
       "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
       "dev": true
     },
     "yargs": {
       "version": "13.3.2",
-      "resolved": "https://npm.americanwhitewater.org:443/yargs/-/yargs-13.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
       "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
       "dev": true,
       "requires": {
@@ -28351,13 +28305,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "https://npm.americanwhitewater.org:443/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
@@ -28406,7 +28360,7 @@
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
@@ -28417,7 +28371,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://npm.americanwhitewater.org:443/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -28428,7 +28382,7 @@
     },
     "yargs-parser": {
       "version": "13.1.2",
-      "resolved": "https://npm.americanwhitewater.org:443/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
       "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
@@ -28452,13 +28406,13 @@
     },
     "yn": {
       "version": "3.1.1",
-      "resolved": "https://npm.americanwhitewater.org:443/yn/-/yn-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
     "yorkie": {
       "version": "2.0.0",
-      "resolved": "https://npm.americanwhitewater.org:443/yorkie/-/yorkie-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yorkie/-/yorkie-2.0.0.tgz",
       "integrity": "sha512-jcKpkthap6x63MB4TxwCyuIGkV0oYP/YRyuQU5UO0Yz/E/ZAu+653/uov+phdmO54n6BcvFRyyt0RRrWdN2mpw==",
       "dev": true,
       "requires": {
@@ -28470,7 +28424,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://npm.americanwhitewater.org:443/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
@@ -28481,7 +28435,7 @@
         },
         "execa": {
           "version": "0.8.0",
-          "resolved": "https://npm.americanwhitewater.org:443/execa/-/execa-0.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
           "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
           "dev": true,
           "requires": {
@@ -28496,13 +28450,13 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "https://npm.americanwhitewater.org:443/lru-cache/-/lru-cache-4.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
@@ -28512,13 +28466,13 @@
         },
         "normalize-path": {
           "version": "1.0.0",
-          "resolved": "https://npm.americanwhitewater.org:443/normalize-path/-/normalize-path-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
           "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://npm.americanwhitewater.org:443/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -28526,12 +28480,12 @@
     },
     "zen-observable": {
       "version": "0.8.15",
-      "resolved": "https://npm.americanwhitewater.org:443/zen-observable/-/zen-observable-0.8.15.tgz",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
       "version": "0.8.21",
-      "resolved": "https://npm.americanwhitewater.org:443/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
       "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
       "requires": {
         "tslib": "^1.9.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@bit/aw.utility.genid": "1",
     "@carbon/grid": "^10.10.2",
     "@carbon/icons-vue": "^10.11.0",
-    "@carbon/vue": "^2.27.0",
+    "@carbon/vue": "2.27.0",
     "@mapbox/mapbox-gl-draw": "^1.1.2",
     "@mapbox/mapbox-gl-draw-static-mode": "^1.0.1",
     "@turf/along": "^6.0.1",

--- a/src/app/views/river-detail/main-tab/components/rapids-section/__tests__/__snapshots__/rapid-icon-bar.spec.js.snap
+++ b/src/app/views/river-detail/main-tab/components/rapids-section/__tests__/__snapshots__/rapid-icon-bar.spec.js.snap
@@ -5,8 +5,10 @@ exports[`rapid-icon-bar.vue hides character icons and shows edit actions when ed
   <div><button role="button" class="cv-button bx--btn bx--btn--secondary bx--btn--sm" id="edit-button">
       Edit
       <!---->
+      <!---->
     </button> <button role="button" class="cv-button bx--btn bx--btn--danger bx--btn--sm" id="delete-button">
       Delete
+      <!---->
       <!---->
     </button></div>
 </div>


### PR DESCRIPTION
resolves: https://github.com/AmericanWhitewater/wh2o/issues/2012