### PR TITLE
Cleanup Map Instances

### DIFF
--- a/src/app/views/river-detail/components/geometry-edit-modal/components/geometry-editor.vue
+++ b/src/app/views/river-detail/components/geometry-edit-modal/components/geometry-editor.vue
@@ -122,7 +122,8 @@ export default {
     currentGeom: null,
     tooZoomedOut: false,
     noticeHidden: false,
-    mapEditMode: 'automatic'
+    mapEditMode: 'automatic',
+    map: null
   }),
   computed: {
     // these basemaps are different than our other NWI maps because they use the NHD flowlines

--- a/src/app/views/river-detail/components/main-tab/components/rapids-section/components/rapid-map-editor.vue
+++ b/src/app/views/river-detail/components/main-tab/components/rapids-section/components/rapid-map-editor.vue
@@ -53,7 +53,8 @@ export default {
   data: () => ({
     // TODO: we may want to default snapMode on or off depending
     // on whether the point is *already* snapped to the line
-    snapMode: true
+    snapMode: true,
+    map: null
   }),
   computed: {
     ...mapState({
@@ -197,6 +198,11 @@ export default {
         leading: false,
         trailing: true
       })
+    }
+  },
+  beforeDestroy() {
+    if(this.map) {
+      this.map.remove()
     }
   }
 }

--- a/src/app/views/river-detail/components/map-banner.vue
+++ b/src/app/views/river-detail/components/map-banner.vue
@@ -50,6 +50,9 @@ export default {
       required: false
     }
   },
+  data: () => ({
+    map: null
+  }),
   computed: {
     reachGeom () {
       // TODO: get graphql API to return a linestring or geojson instead of this text
@@ -153,6 +156,11 @@ export default {
   mounted () {
     if (mapboxAccessToken && this.reachGeom) {
       this.mountMap()
+    }
+  },
+  beforeDestroy() {
+    if(this.map) {
+      this.map.remove();
     }
   }
 }

--- a/src/app/views/river-index/components/nwi-map.vue
+++ b/src/app/views/river-index/components/nwi-map.vue
@@ -130,7 +130,8 @@ export default {
   data () {
     return {
       mapDataLoading: false,
-      mapboxAccessToken: mapboxAccessToken
+      mapboxAccessToken: mapboxAccessToken,
+      map: null
     }
   },
   computed: {
@@ -513,6 +514,11 @@ export default {
   created () {
     if (this.mapboxAccessToken) {
       this.initMap()
+    }
+  },
+  beforeDestroy() {
+    if(this.map) {
+      this.map.remove();
     }
   }
 }


### PR DESCRIPTION
Cleans up all map instances + resources when not needed.

[https://docs.mapbox.com/mapbox-gl-js/api/map/#map#remove](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#remove)
