### PR TITLE
ensure that geom update submits required fields

### DIFF
--- a/src/app/services/updateReachGeom.js
+++ b/src/app/services/updateReachGeom.js
@@ -20,6 +20,9 @@ export async function updateReachGeom(data) {
           ploc: data.ploc,
           tloc: data.tloc,
           length: data.length,
+          river: data.river,
+          section: data.section,
+          class: data.class
         },
       },
     })

--- a/src/app/store/modules/river-detail.js
+++ b/src/app/store/modules/river-detail.js
@@ -73,22 +73,18 @@ export default {
       }
     },
     async updateGeom(context, geomData) {
-      context.commit('GEOM_UPDATE_REQUEST');
+      context.commit('GEOM_UPDATE_REQUEST', geomData);
 
       const payloadData = {
+        ...context.state.data, // must be first so fields are overridden
         geom: wkx.Geometry.parseGeoJSON(geomData.geom).toWkt(),
         ploc: `${geomData.ploc[0]} ${geomData.ploc[1]}`,
         tloc: `${geomData.tloc[0]} ${geomData.tloc[1]}`,
-        length: geomData.length,
+        length: geomData.length
       };
 
-      const data = {
-        id: context.state.data.id,
-        ...payloadData,
-      }
-
       try {
-        const result = await updateReachGeom(data)
+        const result = await updateReachGeom(payloadData)
 
         if (result.data.errors) {
           context.commit('GEOM_UPDATE_ERROR', result.data.errors);


### PR DESCRIPTION
resolves https://github.com/AmericanWhitewater/wh2o/issues/2077

This bug was introduced by these changes on the API that now require these fields: https://github.com/AmericanWhitewater/wh2o/pull/2043/files#diff-95d4890b955653eaef1006feceb9bcde768f3419d31f66f58e520b1a84b02d16R142-R165

I guess there are two open questions here.

1) @ryangroth5 -- why are those fields now required? Do they need to be required? Should we just revert that on the API and abandon this PR?

2) @drewalth pending Ryan's answer to 1, if we do need to change the front-end, should I go further with this PR and refactor geom update to use the generic update service?
