### PR TITLE
fixes for photo upload form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ VUE_APP_API_BASE_URL=http://localhost:8080/
 VUE_APP_LINK_BASE_URL=https://test.americanwhitewater.org
 VUE_APP_MAPBOX_ACCESS_TOKEN=
 VUE_APP_NWI_TILE_SERVER=http://localhost:8080/tiles/{z}/{x}/{y}.mvt/
-VUE_APP_GRAPHQL_HTTP=http://localhost:8080/graphql/
+
 VUE_APP_APOLLO_DEV_HELPER=
 VUE_APP_CLIENT_ID=
 VUE_APP_CLIENT_SECRET=

--- a/src/app/plugins/apollo-client.js
+++ b/src/app/plugins/apollo-client.js
@@ -1,40 +1,43 @@
-import { ApolloClient } from 'apollo-client'
-import { createUploadLink } from 'apollo-upload-client'
-import { InMemoryCache } from 'apollo-cache-inmemory'
-import { setContext } from 'apollo-link-context'
-import { appLocalStorage } from '@/app/global/services'
-import VueApollo from 'vue-apollo'
+import { ApolloClient } from "apollo-client";
+import { createUploadLink } from "apollo-upload-client";
+import { InMemoryCache } from "apollo-cache-inmemory";
+import { setContext } from "apollo-link-context";
+import { appLocalStorage } from "@/app/global/services";
+import VueApollo from "vue-apollo";
 
 const httpLink = createUploadLink({
-  uri: process.env.VUE_APP_GRAPHQL_HTTP || 'http://localhost:3000/graphql'
-})
+  //this assumption is being made in all the other graphql calls.
+  uri:
+    process.env.VUE_APP_API_BASE_URL + "graphql" ||
+    "http://localhost:3000/graphql",
+});
 
 const authLink = setContext((_, { headers }) => {
-  const authHeader = {}
+  const authHeader = {};
   // get the authentication token from local storage
-  const token = appLocalStorage.getItem('wh2o-auth')
+  const token = appLocalStorage.getItem("wh2o-auth");
 
   if (token) {
-    authHeader.Authorization = `Bearer ${token}`
+    authHeader.Authorization = `Bearer ${token}`;
   }
 
   return {
     headers: {
       ...headers,
-      ...authHeader
-    }
-  }
-})
+      ...authHeader,
+    },
+  };
+});
 
 const apolloClient = new ApolloClient({
   link: authLink.concat(httpLink),
-  cache: new InMemoryCache()
+  cache: new InMemoryCache(),
   // connectToDevTools: true,
   // credentials: "same-origin"
-})
+});
 
 const apolloProvider = new VueApollo({
-  defaultClient: apolloClient
-})
+  defaultClient: apolloClient,
+});
 
-export default apolloProvider
+export default apolloProvider;

--- a/src/app/services/updatePost.js
+++ b/src/app/services/updatePost.js
@@ -2,7 +2,7 @@ import http from "@/app/http";
 
 export async function updatePost(formData, photo) {
   //if post is coming in with an ID then remove that property.
-  const photoCopy = JSON.parse(JSON.stringify(photo));
+  const photoCopy = Object.assign({}, photo);
   delete photoCopy.id;
   photoCopy.post_id = formData.id;
   return http

--- a/src/app/services/updatePost.js
+++ b/src/app/services/updatePost.js
@@ -1,9 +1,14 @@
-import http from '@/app/http'
+import http from "@/app/http";
 
-export async function updatePost(formData) {
-  return http.post('/graphql', {
-    query: `
-      mutation ($id:ID!, $post: PostInput!) {
+export async function updatePost(formData, photo) {
+  //if post is coming in with an ID then remove that property.
+  const photoCopy = JSON.parse(JSON.stringify(photo));
+  delete photoCopy.id;
+  photoCopy.post_id = formData.id;
+  return http
+    .post("/graphql", {
+      query: `
+      mutation ($id:ID!, $photo_id: ID!, $photo: PhotoInput!, $post: PostInput!) {
           postUpdate(id: $id, post:$post)  {
           id
           detail
@@ -19,9 +24,19 @@ export async function updatePost(formData) {
             uid
           }
         }
+        photoUpdate(id: $photo_id, photo: $photo)
+          {
+            id
+          },
       }`,
-    variables: formData
-  }).then(response => {
-    return response.data
-  })
+      variables: {
+        id: formData.id,
+        post: formData.post,
+        photo: photoCopy,
+        photo_id: photo.id,
+      },
+    })
+    .then((response) => {
+      return response.data;
+    });
 }

--- a/src/app/views/river-detail/components/gallery-tab.vue
+++ b/src/app/views/river-detail/components/gallery-tab.vue
@@ -13,6 +13,7 @@
             <div class="bx--col">
               <div class="toolbar-wrapper">
                 <cv-button
+                    v-if="user.uid"
                   @click="mediaUploadModalVisible = true"
                 >
                   Upload
@@ -48,10 +49,11 @@
     </layout>
     <media-upload-modal
       :visible="mediaUploadModalVisible"
-      section="POST"
+      section="GALLERY"
       @form:cancelled="mediaUploadModalVisible = false"
       @form:success="mediaUploadModalVisible = false"
       @form:error="mediaUploadModalVisible = false"
+      @upload:submitted="refresh()"
     />
   </div>
 </template>
@@ -94,6 +96,14 @@ export default {
   methods: {
     loadRapids (routeId) {
       this.$store.dispatch('RiverRapids/getProperty', routeId)
+    },
+    /**
+     * refresh after an upload.
+     */
+    refresh(){
+      // reset back to page 1, so user can see their uploaded photo.
+      this.loadMedia();
+
     },
     loadMedia (val) {
       // not used currently but needed for `rapids` in the media upload modal when we add that

--- a/src/app/views/river-detail/components/gallery-tab.vue
+++ b/src/app/views/river-detail/components/gallery-tab.vue
@@ -51,9 +51,8 @@
       :visible="mediaUploadModalVisible"
       section="GALLERY"
       @form:cancelled="mediaUploadModalVisible = false"
-      @form:success="mediaUploadModalVisible = false"
+      @form:success="uploadSuccess"
       @form:error="mediaUploadModalVisible = false"
-      @upload:submitted="refresh()"
     />
   </div>
 </template>
@@ -97,16 +96,11 @@ export default {
     loadRapids (routeId) {
       this.$store.dispatch('RiverRapids/getProperty', routeId)
     },
-    /**
-     * refresh after an upload.
-     */
-    refresh(){
-      // reset back to page 1, so user can see their uploaded photo.
+    uploadSuccess () {
+      this.mediaUploadModalVisible = false;
       this.loadMedia();
-
     },
     loadMedia (val) {
-      // not used currently but needed for `rapids` in the media upload modal when we add that
       this.loadRapids(this.reachId)
 
       const data = {
@@ -114,9 +108,8 @@ export default {
         per_page: val ? val.length : 10,
         page: val ? val.page : 1
       }
-      // this.$store.dispatch(galleryActions.FETCH_GALLERY_DATA, data)
 
-    this.$store.dispatch('RiverGallery/getProperty', data)
+      this.$store.dispatch('RiverGallery/getProperty', data)
 
       this.currentlyLoadedImagesFor = this.reachId
     }

--- a/src/app/views/river-detail/components/image-gallery/__tests__/image-gallery.spec.js
+++ b/src/app/views/river-detail/components/image-gallery/__tests__/image-gallery.spec.js
@@ -15,6 +15,9 @@ const mockStore = {
         river: 'Nooksack',
         section: 'The first part'
       }
+    },
+    RiverRapids: {
+      data: []
     }
   }
 }

--- a/src/app/views/river-detail/components/image-gallery/image-gallery.vue
+++ b/src/app/views/river-detail/components/image-gallery/image-gallery.vue
@@ -132,8 +132,8 @@
               <div class="mb-spacing-md">
                 <h6>Rapid</h6>
                 <div
-                  v-if="activeImage.poi_name"
-                  v-text="activeImage.poi_name"
+                  v-if="rapidName"
+                  v-text="rapidName"
                 />
                 <div
                   v-else
@@ -212,15 +212,30 @@ export default {
   }),
   computed: {
     ...mapState({
-      river: state => state.RiverDetail.data
+      river: state => state.RiverDetail.data,
+      rapids: state => state.RiverRapids.data,
     }),
     activeImage () {
       if (this.lightbox.activeImage) {
         return this.images.find(
           image => image.id === this.lightbox.activeImage
-        )
+        );
+      }
+      return null;
+    },
+    activeImageRapid () {
+      if (this.activeImage && this.activeImage.poi_id) {
+        return this.rapids.find(
+          rapid => rapid.id === this.activeImage.poi_id
+        );
       }
       return null
+    },
+    rapidName () {
+      if (this.activeImageRapid && this.activeImageRapid.name) {
+        return this.activeImageRapid.name;
+      }
+      return this.activeImage.poi_name;
     },
     reachLocation () {
       return `${this.river.river}, ${this.river.section}`

--- a/src/app/views/river-detail/components/media-upload-form.vue
+++ b/src/app/views/river-detail/components/media-upload-form.vue
@@ -166,7 +166,7 @@ export default {
       this.formPending = true
       try {
         //upload the details collected from the form, not just reach id etc.
-        await updatePost(this.postFormData,{...this.formData.photo,id:this.formData.id})
+        await updatePost(this.postFormData, { ...this.formData.photo, id: this.formData.id })
 
         this.$emit('form:success')
         this.$store.dispatch('Global/sendToast', {

--- a/src/app/views/river-detail/components/media-upload-form.vue
+++ b/src/app/views/river-detail/components/media-upload-form.vue
@@ -104,9 +104,9 @@ export default {
         caption: null,
         description: null,
         photo_date: null,
-        poi_id: '0',
+        poi_id: null,
         poi_name: null,
-        post_id: '0',
+        post_id: null,
         subject: null
       }
     },
@@ -120,7 +120,6 @@ export default {
     },
     previewUrls: []
   }),
-
   computed: {
     rapids () {
       return this.$store.state.RiverRapids.data
@@ -155,7 +154,7 @@ export default {
         this.postFormData.id = result.post_id
         this.postFormData.post.post_date = result.photo_date
         this.postFormData.post.reach_id = this.$route.params.id
-        this.previewUrls.push(result.image.uri.big)
+        this.previewUrls.push(result.image.uri.medium)
 
       } catch (error) {
         /* eslint-disable-next-line no-console */
@@ -166,7 +165,9 @@ export default {
     async submitPost () {
       this.formPending = true
       try {
-        await updatePost(this.postFormData)
+        //upload the details collected from the form, not just reach id etc.
+        await updatePost(this.postFormData,{...this.formData.photo,id:this.formData.id})
+
         this.$emit('form:success')
         this.$store.dispatch('Global/sendToast', {
           title: 'Media Uploaded',


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- removes VUE_APP_GRAPHQL_HTTP, not being used. replaced with VUE_APP_API_BASE_URL+"graphql"
- changes photo upload type to GALLERY and post type to PHOTO_UPLOAD to get correct ID 
- hides upload if user is not logged in
- refreshes gallery when upload is sent
- uploads the fields collected in the form when it updates the post

* **What is the current behavior?** (You can also link to an open issue here)
- code indicates that the gallery is updating a POST with the id of the reach being so the wrong post is getting updated and regular users are getting a post not authorized error
- code doesn't update fields from the form
- code uses two ways to indicate the graphql endpoint



- **What is the new behavior (if this is a feature change)?**
- explained

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- i don't think so

- **Other information**:
addresses #1797