### PR TITLE
fix gallery so that it shows when users arent logged in

### DIFF
--- a/src/app/views/river-detail/components/gallery-tab.vue
+++ b/src/app/views/river-detail/components/gallery-tab.vue
@@ -13,7 +13,7 @@
             <div class="bx--col">
               <div class="toolbar-wrapper">
                 <cv-button
-                    v-if="user.uid"
+                    v-if="user && user.uid"
                   @click="mediaUploadModalVisible = true"
                 >
                   Upload


### PR DESCRIPTION
addresses bug introduced by https://github.com/AmericanWhitewater/wh2o/issues/1797 that prevented gallery from loading if not logged in