### PR TITLE
fix updatePost service to work for comments like it used to

### DIFF
--- a/src/app/global/components/post-update-modal/post-update-modal.vue
+++ b/src/app/global/components/post-update-modal/post-update-modal.vue
@@ -180,7 +180,7 @@ export default {
       this.formPending = true
       this.$emit('update:pending', true)
 
-      try {  
+      try {
         const result = await updatePost(this.formData)
         if (!result.errors) {
           this.$emit('update:success', result.data.postUpdate.id)

--- a/src/app/services/updatePost.js
+++ b/src/app/services/updatePost.js
@@ -1,14 +1,22 @@
 import http from "@/app/http";
 
 export async function updatePost(formData, photo) {
-  //if post is coming in with an ID then remove that property.
-  const photoCopy = Object.assign({}, photo);
-  delete photoCopy.id;
-  photoCopy.post_id = formData.id;
+  const variables = {
+    id: formData.id,
+    post: formData.post
+  };
+  if (photo) {
+    // if post is coming in with an ID then remove that property.
+    const photoCopy = Object.assign({}, photo);
+    delete photoCopy.id;
+    photoCopy.post_id = formData.id;
+    variables.photo = photoCopy;
+    variables.photo_id = photo.id;
+  }
   return http
     .post("/graphql", {
       query: `
-      mutation ($id:ID!, $photo_id: ID!, $photo: PhotoInput!, $post: PostInput!) {
+      mutation ($id:ID!, ${photo ? "$photo_id: ID!, $photo: PhotoInput!, " : ''}$post: PostInput!) {
           postUpdate(id: $id, post:$post)  {
           id
           detail
@@ -24,17 +32,9 @@ export async function updatePost(formData, photo) {
             uid
           }
         }
-        photoUpdate(id: $photo_id, photo: $photo)
-          {
-            id
-          },
+        ${photo ?  "photoUpdate(id: $photo_id, photo: $photo) { id }," : '' }
       }`,
-      variables: {
-        id: formData.id,
-        post: formData.post,
-        photo: photoCopy,
-        photo_id: photo.id,
-      },
+      variables: variables,
     })
     .then((response) => {
       return response.data;

--- a/src/app/views/river-detail/components/media-upload-form.vue
+++ b/src/app/views/river-detail/components/media-upload-form.vue
@@ -165,7 +165,7 @@ export default {
     async submitPost () {
       this.formPending = true
       try {
-        //upload the details collected from the form, not just reach id etc.
+        // upload the details collected from the form, not just reach id etc.
         await updatePost(this.postFormData, { ...this.formData.photo, id: this.formData.id })
 
         this.$emit('form:success')


### PR DESCRIPTION
the photo upload changes to `updatePost` ended up breaking comments, which use that code without photos (since COMMENT is another type of post).

This fixes that, resolves https://github.com/AmericanWhitewater/wh2o/issues/2141

Ideally these should be entirely separate chunks of code but I'm not sure exactly how photo upload is going to evolve right now and these changes allow both, as they are currently, to continue working, so despite it being a little confusing I thought this would be easier than a bigger refactor with unknown future requirements.