### PR TITLE
just a bit of padding to help clean up the read more link

### DIFF
--- a/src/app/assets/scss/components/_article-card.scss
+++ b/src/app/assets/scss/components/_article-card.scss
@@ -135,8 +135,10 @@
 .read-more {
   color: $ui-02;
   font-weight: 200;
-  right: 15px;
-  bottom: 6px;
+  right: 0;
+  bottom: 0;
+  padding: 6px;
+  padding-right: 16px;
   background: $ui-02;
   position: absolute;
 }


### PR DESCRIPTION
The read more link can be handled with pure CSS, so these last few commits have been changing it to that. 

The "... Read More" link is positioned on top of the text. It's a little sloppy, but I think it's the way. 

I originally positioned the link away from the right edge, but text would peek through. I should have used padding so this pull request is only updating that. 
