### PR TITLE
Feature/tweak published unpublished toggles

### DIFF
--- a/src/app/global/mixins/index.js
+++ b/src/app/global/mixins/index.js
@@ -6,7 +6,6 @@ export * from "./format-date";
 export * from "./shadow-dom-fixed-height-offset";
 export * from "./object-permissions-helpers";
 export * from "./reach-classes";
-export * from "./reach-published-states";
 export * from "./map-helpers";
 export * from "./basemap-toggle";
 export * from "./asset-url";

--- a/src/app/global/mixins/reach-published-states.js
+++ b/src/app/global/mixins/reach-published-states.js
@@ -1,8 +1,0 @@
-export const reachPublishedStates = {
-  data: () => ({
-    reachPublishedStates: {
-      v: "Published",
-      u: "Draft",
-    }
-  })
-};

--- a/src/app/services/deleteReach.js
+++ b/src/app/services/deleteReach.js
@@ -1,0 +1,16 @@
+import http from "@/app/http"
+
+export async function deleteReach(id) {
+  return http.post('graphql', {
+    query: `
+            mutation ($id:ID!) {
+              reachDelete(id: $id) {
+                id
+              }
+            }
+          `,
+    variables: {
+      id
+    }
+  }).then(res => res.data)
+}

--- a/src/app/services/getReach.js
+++ b/src/app/services/getReach.js
@@ -18,6 +18,11 @@ export async function getReach(id) {
                   plon
                   geom
                   status
+                  permissions {
+                    domain
+                    permission
+                    result
+                  }
                   readingsummary {
                       adjusted_reach_class
                       gauge_estimated

--- a/src/app/services/index.js
+++ b/src/app/services/index.js
@@ -3,6 +3,7 @@ export * from "./createReach";
 export * from "./deleteComment";
 export * from "./deletePost";
 export * from "./deleteRapid";
+export * from "./deleteReach";
 export * from "./getAccidents";
 export * from "./getAffiliates";
 export * from "./getArticle";

--- a/src/app/store/modules/river-detail.js
+++ b/src/app/store/modules/river-detail.js
@@ -1,7 +1,7 @@
 import actions from '@/app/store/actions'
 import mutations from '@/app/store/mutations'
 import wkx from "wkx";
-import {updateReach, getReach, updateReachGeom} from "@/app/services"
+import {updateReach, getReach, deleteReach, updateReachGeom} from "@/app/services"
 
 export default {
   namespaced: true,
@@ -37,7 +37,11 @@ export default {
         data: null,
         refId: null
       })
-    }
+    },
+
+    ['DELETE_REQUEST']() { },
+
+    ['DELETE_SUCCESS']() { }
   },
   actions: {
     ...actions,
@@ -106,6 +110,20 @@ export default {
 
       } catch (error) {
         context.commit('GEOM_UPDATE_ERROR', error);
+      }
+    },
+    async deleteReach(context, data) {
+      context.commit('DELETE_REQUEST', data);
+      try {
+        const result = await deleteReach(data)
+        if (!result.errors) {
+          context.commit('DELETE_SUCCESS', result.data.reachDelete);
+          context.commit('DATA_RESET');
+        } else {
+          context.commit('DATA_ERROR', "error");
+        }
+      } catch (error) {
+        context.commit('DATA_ERROR', error)
       }
     },
     dataReset(context) {

--- a/src/app/views/river-detail/components/main-tab/components/comments-section/components/comment.vue
+++ b/src/app/views/river-detail/components/main-tab/components/comments-section/components/comment.vue
@@ -71,7 +71,7 @@ import {
   shadowDomFixedHeightOffset,
   objectPermissionsHelpersMixin,
 } from "@/app/global/mixins";
-import {deleteComment} from "@/app/services";
+import { deleteComment } from "@/app/services";
 import { baseUrl } from "@/app/environment";
 
 export default {

--- a/src/app/views/river-detail/components/reach-title-edit-modal.vue
+++ b/src/app/views/river-detail/components/reach-title-edit-modal.vue
@@ -20,20 +20,6 @@
           label="Section"
           class="mb-spacing-md"
         />
-        <cv-select
-          v-model="formData.status"
-          label="Status"
-          class="mb-spacing-md"
-          helper-text="'Published' reaches will appear within 5 minutes of saving. 'Drafts' need to be updated to 'Published' in order to appear."
-        >
-          <cv-select-option
-            v-for="(label, val) in reachPublishedStates"
-            :key="val"
-            :value="val"
-          >
-            {{ label }}
-          </cv-select-option>
-        </cv-select>
       </template>
       <template slot="secondary-button"> Cancel </template>
       <template slot="primary-button"> Submit </template>
@@ -41,14 +27,11 @@
   </div>
 </template>
 <script>
-import {
-  shadowDomFixedHeightOffset,
-  reachPublishedStates,
-} from "@/app/global/mixins";
+import { shadowDomFixedHeightOffset } from "@/app/global/mixins";
 import { mapState } from "vuex";
 export default {
   name: "reach-title-edit-modal",
-  mixins: [shadowDomFixedHeightOffset, reachPublishedStates],
+  mixins: [shadowDomFixedHeightOffset],
   props: {
     visible: {
       type: Boolean,
@@ -81,7 +64,6 @@ export default {
             length: this.formData.length,
             avggradient: this.formData.avggradient,
             maxgradient: this.formData.maxgradient,
-            status: this.formData.status,
           },
         });
       });

--- a/src/app/views/river-detail/river-creator.vue
+++ b/src/app/views/river-detail/river-creator.vue
@@ -100,20 +100,6 @@
               <cv-text-input v-model="reach.maxgradient" label="Max Gradient" />
               <div class="mb-spacing-lg" />
             </template>
-            <cv-select
-              v-model="reach.status"
-              label="Status"
-              class="mb-spacing-md"
-              helper-text="'Published' reaches will appear within 5 minutes of saving. 'Drafts' need to be updated to 'Published' in order to appear."
-            >
-              <cv-select-option
-                v-for="(label, val) in reachPublishedStates"
-                :key="val"
-                :value="val"
-              >
-                {{ label }}
-              </cv-select-option>
-            </cv-select>
             <cv-button-set>
               <cv-button
                 :disabled="createLoading"
@@ -138,7 +124,7 @@
 </template>
 <script>
 import { createReach } from "@/app/services";
-import { reachClasses, reachPublishedStates } from "@/app/global/mixins";
+import { reachClasses } from "@/app/global/mixins";
 import turfLength from "@turf/length";
 import GeometryEditor from "@/app/views/river-detail/components/geometry-edit-modal/components/geometry-editor.vue";
 import ContentEditor from "@/app/global/components/content-editor/content-editor.vue";
@@ -151,7 +137,7 @@ export default {
     ContentEditor,
     UtilityBlock,
   },
-  mixins: [reachClasses, reachPublishedStates],
+  mixins: [reachClasses],
   data: () => ({
     geom: null,
     createLoading: false,
@@ -172,7 +158,7 @@ export default {
       section: "",
       tloc: "",
       zipcode: "",
-      status: "v",
+      status: "v", // v means 'verified' or published
     },
   }),
   computed: {
@@ -225,18 +211,26 @@ export default {
           });
           this.$router.push(`/river-detail/${result.data.reachUpdate.id}`);
         } else {
-
           this.$store.dispatch("Global/sendToast", {
             kind: "error",
             title: "Error",
-            subtitle: "Failed to Create New Reach: "+(Object.keys(result.errors).map(x=>result.errors[x]?.message ?? '').join(','))
+            subtitle:
+              "Failed to Create New Reach: " +
+              Object.keys(result.errors)
+                .map((x) => result.errors[x]?.message ?? "")
+                .join(","),
           });
         }
       } catch (error) {
-
         this.$store.dispatch("Global/sendToast", {
           kind: "error",
-          title: "Error: "+(error?.message ? error.message:(Object.keys(error).map(x=>error[x]?.message ?? '').join(','))),
+          title:
+            "Error: " +
+            (error?.message
+              ? error.message
+              : Object.keys(error)
+                  .map((x) => error[x]?.message ?? "")
+                  .join(",")),
           text: "Something went wrong.",
         });
       } finally {


### PR DESCRIPTION
This reconfigures the reach status / publishing / deleting question to be more in line with desired workflow and API reality.

- reach create now submits `status: "v"` regardless and there's no toggle
- reach edit shows delete button *if* user has delete permission
- delete button submits a `reachDelete` request to graphql rather than using reachUpdate to modify status