### PR TITLE
adds flow button back on a no-gauge page if in edit mode.

### DIFF
--- a/src/app/views/river-detail/components/flow-tab/flow-tab.vue
+++ b/src/app/views/river-detail/components/flow-tab/flow-tab.vue
@@ -145,6 +145,14 @@
 
         </template>
         <template v-else>
+          <div>
+            <a v-if="editMode"
+               class="cv-button mb-spacing-md bx--btn bx--btn--tertiary bx--btn--sm"
+               :href="formatLinkUrl(`/content/StreamTeam/edit-correlations/?reach_id=${$route.params.id}`)"
+               target="_blank"
+            >Edit Flows</a>
+          </div>
+
           <utility-block
               state="content"
               title="No Gages"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Adds edit flows button if no gauge is associated with a river

* **What is the current behavior?** (You can also link to an open issue here)
* no way to edit flows if no gauge already exists

- **What is the new behavior (if this is a feature change)?**
- edit flows buttons shows up on form in edit mode

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
* no

- **Other information**:
- no
