### PR TITLE
ensure that activeGage only searches records with gages

### DIFF
--- a/src/app/views/river-detail/components/flow-tab/flow-tab.vue
+++ b/src/app/views/river-detail/components/flow-tab/flow-tab.vue
@@ -348,7 +348,7 @@ export default {
     },
 
     activeGage () {
-      return this.gages ? this.gages.find(g => g.gauge.id === this.activeGageId) : null
+      return this.gages ? this.gagesWithGage.find(g => g.gauge.id === this.activeGageId) : null
     },
     activeMetric () {
       if (this.metrics) {


### PR DESCRIPTION
@mattanger I think this is your area of the code, I don't know enough about gage data structures to be 100% confident here, but the JS error that was breaking the Pit flow tab was a fairly obvious fix -- it was trying to call `g.gauge.id` on a record for which `g.gauge` was null

addresses https://github.com/AmericanWhitewater/wh2o/issues/2470