### PR TITLE
fix issue where trip report multi photo uploader uploads duplicates

### DIFF
--- a/src/app/global/components/multi-photo-uploader/multi-photo-uploader.vue
+++ b/src/app/global/components/multi-photo-uploader/multi-photo-uploader.vue
@@ -94,7 +94,10 @@ export default {
     },
   },
   data: function () {
-    return { images: [] };
+    return {
+      images: [],
+      uploadingImages: [],
+    };
   },
   computed: {
     ...mapState({
@@ -106,8 +109,15 @@ export default {
     async setFile(input) {
       if (input && input.length) {
         input.forEach(async (f) => {
-          await this.uploadImage(f.file);
-          this.$refs.fileUploader.internalFiles.pop();
+          if (!this.uploadingImages.includes(f)) {
+            this.uploadingImages.push(f);
+            await this.uploadImage(f.file);
+            this.$refs.fileUploader.internalFiles.splice(
+              this.$refs.fileUploader.internalFiles.indexOf(f),
+              1
+            );
+            this.uploadingImages.splice(this.uploadingImages.indexOf(f), 1);
+          }
         });
       }
     },


### PR DESCRIPTION
addresses https://github.com/AmericanWhitewater/wh2o/issues/2505. Turns out whenever a carbon file upload component emits `change`, it emits the entire list of files within it, so if some files are still pending, the code was calling upload an extra time (or more).