### PR TITLE
first pass at fixing gauge range display

### DIFF
--- a/src/app/global/lib/gages/index.js
+++ b/src/app/global/lib/gages/index.js
@@ -63,21 +63,22 @@ export function getEmptyReading() {
   };
 }
 
-export function rangeToClass(range) {
-  switch (range[0]) {
+export function rangeToClass(minRange, maxRange) {
+  // this could be *way* simpler but the backend defines duplicate ranges with different "R" values
+  // so we need to try to match them here
+  switch (minRange[0]) {
     case "R":
-      switch (range[1]) {
+      switch (minRange[1]) {
         case "0":
-        case "1":
-        case "2":
-          return "low-runnable";
-        case "3":
+          if (maxRange[1] === "9") {
+            return "runnable";
+          } else {
+            return "low-runnable";
+          }
         case "4":
-        case "5":
           return "runnable";
+        case "5":
         case "6":
-        case "7":
-        case "8":
           return "high-runnable";
       }
       return "runnable";
@@ -93,11 +94,11 @@ export function classToColor(c) {
     case "below-recommended":
       return "#FF8785";
     case "low-runnable":
-      return "#59E78D";
+      return "#1fd561";
     case "runnable":
       return "#59E78D";
     case "high-runnable":
-      return "#59E78D";
+      return "#9cf1bb";
     case "above-recommended":
       return "#68DFE9";
   }

--- a/src/app/views/river-detail/components/flow-tab/components/flow-chart/flow-chart.vue
+++ b/src/app/views/river-detail/components/flow-tab/components/flow-chart/flow-chart.vue
@@ -222,8 +222,7 @@ export default {
         if(graphRanges.length)
         {
           let graphBackgrounds = [
-              ...graphRanges.map(x=>({class:rangeToClass(x.range_min), min:x.min,max:x.min+((x.max-x.min)/2)})),
-              ...graphRanges.map(x=>({class:rangeToClass(x.range_max), min:x.min+((x.max-x.min)/2),max:x.max}))]
+              ...graphRanges.map(x=>({class:rangeToClass(x.range_min, x.range_max), min:x.min,max:x.max}))]
            graphBackgrounds = [
               ...graphBackgrounds,
               {

--- a/src/app/views/river-detail/components/flow-tab/components/level-legend.vue
+++ b/src/app/views/river-detail/components/flow-tab/components/level-legend.vue
@@ -154,7 +154,7 @@ export default {
       }
       if (this.enumeratedRanges?.length) {
         const legend = this.legendItems.map(x => x.color_class)
-        const rangesRepresented = uniq([...this.enumeratedRanges.map(x => x.min_class), ...this.enumeratedRanges.map(x => x.max_class)])
+        const rangesRepresented = uniq([...this.enumeratedRanges.map(x => x.class)])
         const rangesMissing = difference(legend, rangesRepresented)
         if (rangesMissing.indexOf('below-recommended') >= 0) {
           rv.hasMin = false
@@ -176,17 +176,13 @@ export default {
 
       const mins = x => ({
         val: x.min,
-        class: rangeToClass(x.range_min),
-        min_class: rangeToClass(x.range_min),
-        max_class: rangeToClass(x.range_max),
+        class: rangeToClass(x.range_min, x.range_max),
         range: x
       })
 
       const maxs = x => ({
         val: x.max,
-        class: rangeToClass(x.range_max),
-        min_class: rangeToClass(x.range_min),
-        max_class: rangeToClass(x.range_max),
+        class: rangeToClass(x.range_min, x.range_max),
         range: x
       })
       return [...this.filteredRanges.map(mins), ...this.filteredRanges.map(maxs)].sort((x, y) => y.val - x.val)


### PR DESCRIPTION
I am really not sure about this, the "range" definition stuff is extremely confusing -- as far as I can tell, there are clearly defined options for users defining ranges, but those options include duplicates:

![image](https://user-images.githubusercontent.com/1222063/175189074-a93cd7b2-a1f2-427b-98a1-067fe263d306.png)

I changed the front-end code to reflect the ranges that users are allowed to define today. I guess it's possible that misses ranges users were historically able to define, I have no idea. @ryangroth5 

I've tested this on a bunch of reaches and it seems to both a) work and b) resolve @AWKevin's issues (i.e. make this feature work)...but again, I do not feel like I have a real understanding of how this range stuff works, so maybe I'm missing something.

Addresses [Need Color Depiction of "Low Runnable" and "High Runnable" Flow Ranges](https://github.com/AmericanWhitewater/wh2o/issues/1405)