### PR TITLE
change reach gallery to order by revision for consistency

### DIFF
--- a/src/app/services/getReachGallery.js
+++ b/src/app/services/getReachGallery.js
@@ -9,7 +9,7 @@ export async function getReachGallery(id, pagination) {
             photos(
               first: ${pagination.perPage},
               page: ${pagination.page}, 
-              orderBy: [{field: DATE, order: DESC}, {field: POST_DATE, order: DESC}, {field: CREATED_DATE, order: DESC}]
+              orderBy: [{field: REVISION, order: DESC}]
             ) {
               data {
                 id

--- a/src/app/services/getReachGalleryIndex.js
+++ b/src/app/services/getReachGalleryIndex.js
@@ -8,7 +8,7 @@ export async function getReachGalleryIndex(id) {
           reach(id: ${id}) {
             photos(
               first: 2500,
-              orderBy: [{field: DATE, order: DESC}, {field: POST_DATE, order: DESC}, {field: CREATED_DATE, order: DESC}],
+              orderBy: [{field: REVISION, order: DESC}],
               page: 1
             ) {
               data {


### PR DESCRIPTION
accomplishes "option 1" from https://github.com/AmericanWhitewater/wh2o/issues/2477
