### PR TITLE
Bug/change alert and report buttons for logged out users

### DIFF
--- a/src/app/global/components/index.js
+++ b/src/app/global/components/index.js
@@ -9,6 +9,7 @@ export { default as EditModeToggle } from './edit-mode-toggle/edit-mode-toggle.v
 export { default as FeatureCard } from './feature-card/feature-card.vue'
 export { default as FlowRangeHelpModal } from './flow-range-help-modal/flow-range-help-modal.vue'
 export { default as ImageSelectorModal } from './image-selector-modal/image-selector-modal.vue'
+export { default as LoginButton } from './login-button/login-button.vue'
 export { default as MultiPhotoUploader } from './multi-photo-uploader/multi-photo-uploader.vue'
 export { default as PageBanner } from './page-banner/page-banner.vue'
 export { default as PageDescription } from './page-description/page-description.vue'

--- a/src/app/global/components/login-button/login-button.vue
+++ b/src/app/global/components/login-button/login-button.vue
@@ -1,0 +1,40 @@
+<template>
+  <cv-button
+    kind="secondary"
+    size="small"
+    :class="buttonClass"
+    @keydown.enter="goToLogin"
+    @click.exact="goToLogin"
+  >
+    {{ buttonText }}
+  </cv-button>
+</template>
+
+<script>
+import { laravelDeploy } from "@/app/environment"
+
+export default {
+  name: "edit-mode-toggle",
+  props: {
+    buttonText: {
+      type: String,
+      default: "Log in"
+    },
+    buttonClass: {
+      type: String
+    }
+  },
+  methods: {
+    goToLogin() {
+      if (laravelDeploy) {
+        this.goToLink('/content/User/login');
+      } else {
+        this.$router.push('/user/access/login');
+      }
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/app/views/river-detail/components/main-tab/components/rapids-section/components/rapid-item.vue
+++ b/src/app/views/river-detail/components/main-tab/components/rapids-section/components/rapid-item.vue
@@ -99,15 +99,7 @@
                   This rapid does not have a description.
                   <br>
                   <template v-if="!user">
-                    <cv-button
-                      kind="secondary"
-                      size="small"
-                      class="mt-spacing-md"
-                      @keydown.enter="$router.push('/user/access/login')"
-                      @click.exact="$router.push('/user/access/login')"
-                    >
-                      Log in to add one.
-                    </cv-button>
+                    <login-button buttonClass="mt-spacing-md" buttonText="Log in to add one" />
                   </template>
                   <template v-if="user && !editMode">
                     <cv-button
@@ -131,12 +123,14 @@
 </template>
 <script>
 import RapidIconBar from "./rapid-icon-bar";
+import { LoginButton } from "@/app/global/components";
 import { assetUrl } from "@/app/global/mixins";
 
 export default {
   name: "rapids-item",
   components: {
     RapidIconBar,
+    LoginButton,
   },
   mixins: [assetUrl],
   props: {

--- a/src/app/views/river-detail/components/main-tab/components/recent-alerts/components/side-bar-alerts.vue
+++ b/src/app/views/river-detail/components/main-tab/components/recent-alerts/components/side-bar-alerts.vue
@@ -2,15 +2,21 @@
   <div class="sidebar-alerts mb-spacing-md">
     <span class="header-row">
       <h4 class="mb-spacing-sm">Alerts</h4>
-      <cv-button
-        id="new-alert"
-        kind="secondary"
-        :disabled="loading"
-        size="small"
-        class="mb-spacing-sm"
-        @click.exact="openModal"
-        @keydown.enter="newAlertModalVisible = true"
-      >New Alert</cv-button>
+      <template v-if="user">
+        <cv-button
+          id="new-alert"
+          kind="secondary"
+          :disabled="loading"
+          size="small"
+          class="mb-spacing-sm"
+          @click.exact="openModal"
+          @keydown.enter="newAlertModalVisible = true"
+          >+ New Alert</cv-button
+        >
+      </template>
+      <template v-else>
+        <login-button buttonClass="mb-spacing-sm" buttonText="Log in to add an alert" />
+      </template>
     </span>
     <template v-if="loading">
       <cv-inline-loading state="loading" />
@@ -58,11 +64,12 @@
 </template>
 <script>
 import { mapState } from 'vuex'
-import PostUpdateModal from '@/app/global/components/post-update-modal/post-update-modal'
+import { LoginButton, PostUpdateModal } from '@/app/global/components'
 export default {
   name: 'sidebar-alerts',
   components: {
-    PostUpdateModal
+    PostUpdateModal,
+    LoginButton
   },
   data: () => ({
     newAlertModalVisible: false

--- a/src/app/views/river-detail/components/main-tab/components/reports-section/reports-section.vue
+++ b/src/app/views/river-detail/components/main-tab/components/reports-section/reports-section.vue
@@ -7,7 +7,6 @@
       Trip Reports
     </h2>
     <cv-button
-      v-if="user"
       id="new-report"
       kind="secondary"
       size="small"

--- a/src/app/views/river-detail/components/main-tab/components/reports-section/reports-section.vue
+++ b/src/app/views/river-detail/components/main-tab/components/reports-section/reports-section.vue
@@ -6,16 +6,24 @@
     <h2 class="mb-spacing-md">
       Trip Reports
     </h2>
-    <cv-button
-      id="new-report"
-      kind="secondary"
-      size="small"
-      class="mb-spacing-xl"
-      :disabled="loading"
-      @click.exact="navigateToNewReportForm"
-    >
-      + New Report
-    </cv-button>
+    <template v-if="user">
+      <cv-button
+        id="new-report"
+        kind="secondary"
+        size="small"
+        class="mb-spacing-xl"
+        :disabled="loading"
+        @click.exact="navigateToNewReportForm"
+      >
+        + New Report
+      </cv-button>
+    </template>
+    <template v-else>
+      <login-button
+        buttonClass="mb-spacing-xl"
+        buttonText="Log in to add a report"
+      />
+    </template>
     <template v-if="loading">
       <utility-block state="loading" />
     </template>
@@ -45,13 +53,14 @@
 </template>
 
 <script>
-import UtilityBlock from '@/app/global/components/utility-block/utility-block'
+import { LoginButton, UtilityBlock } from '@/app/global/components';
 import { getReachReports } from '@/app/services'
 import { mapState } from 'vuex'
 import { ReportPreview } from "@/app/views/river-detail/components/reports-tab/components";
 export default {
   name: 'reports-section',
   components: {
+    LoginButton,
     UtilityBlock,
     ReportPreview
   },

--- a/src/app/views/river-detail/components/reports-tab/reports-tab.vue
+++ b/src/app/views/river-detail/components/reports-tab/reports-tab.vue
@@ -10,13 +10,17 @@
           <div class="bx--row">
             <div class="bx--col mb-spacing-md"><h2>Trip Reports</h2></div>
             <div class="bx--col">
-              <cv-button
-                v-if="user"
-                size="small"
-                @click.exact="$router.push({ name: 'new-report' })"
-              >
-                + New Trip Report
-              </cv-button>
+              <template v-if="user">
+                <cv-button
+                  size="small"
+                  @click.exact="$router.push({ name: 'new-report' })"
+                >
+                  + New Trip Report
+                </cv-button>
+              </template>
+              <template v-else>
+                <login-button buttonText="Log in to add a report" />
+              </template>
             </div>
           </div>
           <template v-if="loading">
@@ -52,8 +56,7 @@
 </template>
 <script>
 import { mapState } from "vuex";
-import UtilityBlock from "@/app/global/components/utility-block/utility-block";
-import TablePagination from "@/app/global/components/table-pagination/table-pagination";
+import { LoginButton, TablePagination, UtilityBlock } from "@/app/global/components";
 import { objectPermissionsHelpersMixin } from "@/app/global/mixins";
 import { Layout } from "@/app/global/layout";
 import { ReportPreview } from "./components";
@@ -61,6 +64,7 @@ export default {
   name: "reports-tab",
   components: {
     Layout,
+    LoginButton,
     UtilityBlock,
     TablePagination,
     ReportPreview,


### PR DESCRIPTION
- replaces "new alert" and "new report" buttons on main tab with "log in to add one" when users are not signed in
- fixes unreported bug where "Log in to add one" in the rapids list linked to broken (Vue app) login page on production, not normal login page


this is meant to address both https://github.com/AmericanWhitewater/wh2o/issues/2592 and https://github.com/AmericanWhitewater/wh2o/issues/2593