### PR TITLE
ensure selecting gauge in TR form actually populates metric_id field

### DIFF
--- a/src/app/views/river-detail/components/reports-tab/components/report-form.vue
+++ b/src/app/views/river-detail/components/reports-tab/components/report-form.vue
@@ -163,7 +163,7 @@ export default {
         // if switching between gauges, do nothing
         // if switching from gauge to no gauge or vice versa,
         // update reading and metric_id accordingly
-        if (newVal && (oldVal === "" || oldVal === undefined)) {
+        if (newVal && (!oldVal || oldVal === undefined)) {
           this.formData.reading = "";
           const selectedGage = this.gages.find((x) => x.gauge.id === newVal);
           this.formData.metric_id = `${selectedGage?.gauge_metric}`;


### PR DESCRIPTION
addresses [Trip Report Issue When User Does Not Select Units for Flow#2717](https://github.com/AmericanWhitewater/wh2o/issues/2717)