### PR TITLE
ensure trip reports section of main tab reloads for new reaches

### DIFF
--- a/src/app/views/river-detail/components/main-tab/components/reports-section/reports-section.vue
+++ b/src/app/views/river-detail/components/main-tab/components/reports-section/reports-section.vue
@@ -76,7 +76,18 @@ export default {
   computed: {
     ...mapState({
       user: state => state.User.data
-    })
+    }),
+    reachId() {
+      return this.$route.params.id;
+    },
+  },
+  watch: {
+    reachId: {
+      immediate: true,
+      handler: function () {
+        this.loadReports();
+      }
+    }
   },
   methods: {
     navigateToNewReportForm () {
@@ -92,7 +103,7 @@ export default {
     async loadReports () {
       this.loading = true
 
-      const result = await getReachReports(this.$route.params.id, { perPage: 3, page: 1 })
+      const result = await getReachReports(this.reachId, { perPage: 3, page: 1 })
 
       if (!result.errors) {
         result.data.posts.data.forEach((report) => {
@@ -106,9 +117,6 @@ export default {
 
       this.loading = false
     },
-  },
-  mounted() {
-    this.loadReports()
   }
 }
 </script>


### PR DESCRIPTION
resolves [Trip Reports appear on other river pages in specific navigation pattern#2734](https://github.com/AmericanWhitewater/wh2o/issues/2734)

talked a big game about doing a refactor while working on this task but this instance of this problem turned out to be quite simple.