### PR TITLE
Feature/migrate away from mapbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21327,10 +21327,10 @@
         "object-visit": "^1.0.0"
       }
     },
-    "mapbox-gl": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.1.tgz",
-      "integrity": "sha512-GSyubcoSF5MyaP8z+DasLu5v7KmDK2pp4S5+VQ5WdVQUOaAqQY4jwl4JpcdNho3uWm2bIKs7x1l7q3ynGmW60g==",
+    "maplibre-gl": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-1.15.3.tgz",
+      "integrity": "sha512-ZuOhLCNgp7Yl1L9uyKgZeuo7kKdewP0iWtmEXsZ/snp0JiVkR1Kl+m1rsfKT/wpm/O4zZ7mUGxF16cYbMIFDRA==",
       "requires": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -21346,7 +21346,7 @@
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.2.1",
         "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^1.0.1",
@@ -21360,7 +21360,7 @@
         "rw": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-          "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+          "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "graphql": "^15.3.0",
     "jest-transform-graphql": "^2.1.0",
     "lodash": "^4.17.20",
-    "mapbox-gl": "^1.10.0",
+    "maplibre-gl": "^1.15.3",
     "moment": "^2.29.4",
     "nanoid": "^3.3.4",
     "rbush-knn": "^3.0.1",

--- a/src/app/app.vue
+++ b/src/app/app.vue
@@ -44,7 +44,7 @@ export default {
 
  <style lang="scss">
 @import "/assets/scss/app";
-@import "~mapbox-gl/dist/mapbox-gl.css";
+@import "~maplibre-gl/dist/maplibre-gl.css";
 
 .slide-left-enter-active,
 .slide-left-leave-active,

--- a/src/app/environment/index.js
+++ b/src/app/environment/index.js
@@ -9,6 +9,7 @@
  */
 
 const {
+  VUE_APP_ARCGIS_API_KEY,
   VUE_APP_LARAVEL_DEPLOY,
   VUE_APP_WP_API_URL,
   VUE_APP_NWI_TILE_SERVER,
@@ -23,6 +24,7 @@ const {
 } = process.env
 
 const environment = NODE_ENV.toLowerCase()
+const arcgisApiKey = VUE_APP_ARCGIS_API_KEY
 const apiBaseUrl = VUE_APP_API_BASE_URL
 const appBaseUrl = VUE_APP_BASE_URL
 const assetBaseUrl = STATIC_ASSET_URL || VUE_APP_API_BASE_URL
@@ -36,6 +38,7 @@ const baseUrl = VUE_APP_LINK_BASE_URL
 
 export {
   environment,
+  arcgisApiKey,
   apiBaseUrl,
   appBaseUrl,
   assetBaseUrl,

--- a/src/app/global/mixins/basemap-toggle.js
+++ b/src/app/global/mixins/basemap-toggle.js
@@ -1,4 +1,5 @@
 import NwiBasemapToggle from "@/app/views/river-index/components/nwi-basemap-toggle.vue";
+import { arcgisApiKey } from "@/app/environment";
 
 export const basemapToggleMixin = {
   computed: {
@@ -17,14 +18,13 @@ export const basemapToggleMixin = {
   },
   methods: {
     baseMapUrlFor(mapType) {
-      if (mapType === "topo") {
-        return "mapbox://styles/mapbox/outdoors-v11";
-      } else if (mapType === "satellite") {
-        // custom version of `satellite-v8` that includes icons that already exist in `outdoors-v11`
-        return "mapbox://styles/americanwhitewater/ck1h4j4hm2bts1cpueefclrrn";
-      } else {
-        return "mapbox://styles/mapbox/outdoors-v11";
+      let basemapStyle;
+      if (mapType === "satellite") {
+        basemapStyle = "ArcGIS:Imagery:Standard"
+      } else { // mapType == "topo"
+        basemapStyle = "ArcGIS:Topographic:Base"
       }
+      return `https://basemaps-api.arcgis.com/arcgis/rest/services/styles/${basemapStyle}?type=style&token=${arcgisApiKey}`;
     }
   }
 };

--- a/src/app/global/mixins/basemap-toggle.js
+++ b/src/app/global/mixins/basemap-toggle.js
@@ -20,9 +20,9 @@ export const basemapToggleMixin = {
     baseMapUrlFor(mapType) {
       let basemapStyle;
       if (mapType === "satellite") {
-        basemapStyle = "ArcGIS:Imagery:Standard"
+        basemapStyle = "ArcGIS:Imagery"
       } else { // mapType == "topo"
-        basemapStyle = "ArcGIS:Topographic:Base"
+        basemapStyle = "ArcGIS:Topographic"
       }
       return `https://basemaps-api.arcgis.com/arcgis/rest/services/styles/${basemapStyle}?type=style&token=${arcgisApiKey}`;
     }

--- a/src/app/views/news-page/__tests__/article-detail.spec.js
+++ b/src/app/views/news-page/__tests__/article-detail.spec.js
@@ -1,7 +1,7 @@
 import { createWrapper } from '@/utils'
 import ArticleDetail from '../components/article-detail.vue'
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
   Map: () => ({})
 }))
 

--- a/src/app/views/news-page/__tests__/news-page.spec.js
+++ b/src/app/views/news-page/__tests__/news-page.spec.js
@@ -1,7 +1,7 @@
 import { createWrapper } from '@/utils'
 import NewsPage from '../news-page.vue'
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
   Map: () => ({})
 }))
 

--- a/src/app/views/river-detail/__tests__/accidents-tab.spec.js
+++ b/src/app/views/river-detail/__tests__/accidents-tab.spec.js
@@ -1,7 +1,7 @@
 import AccidentsTab from '@/app/views/river-detail/components/accidents-tab.vue'
 import { createWrapper } from '@/utils'
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
   Map: () => ({})
 }))
 

--- a/src/app/views/river-detail/__tests__/gallery-tab.spec.js
+++ b/src/app/views/river-detail/__tests__/gallery-tab.spec.js
@@ -1,7 +1,7 @@
 import GalleryTab from '@/app/views/river-detail/components/gallery-tab/gallery-tab.vue'
 import { createWrapper } from '@/utils'
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
   Map: () => ({})
 }))
 

--- a/src/app/views/river-detail/__tests__/map-tab.spec.js
+++ b/src/app/views/river-detail/__tests__/map-tab.spec.js
@@ -1,7 +1,7 @@
 import { createWrapper } from '@/utils'
 import MapTab from '@/app/views/river-detail/components/map-tab/map-tab.vue'
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
   Map: () => ({})
 }))
 

--- a/src/app/views/river-detail/__tests__/news-tab.spec.js
+++ b/src/app/views/river-detail/__tests__/news-tab.spec.js
@@ -1,7 +1,7 @@
 import NewsTab from '@/app/views/river-detail/components/news-tab/news-tab.vue'
 import { createWrapper } from '@/utils'
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
   Map: () => ({})
 }))
 

--- a/src/app/views/river-detail/__tests__/river-detail.spec.js
+++ b/src/app/views/river-detail/__tests__/river-detail.spec.js
@@ -3,7 +3,7 @@ test.todo('revive tests')
 // import { createWrapper } from '@/utils'
 // import RiverDetail from '../river-detail.vue'
 
-// jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+// jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
 //   Map: () => ({})
 // }))
 

--- a/src/app/views/river-detail/components/geometry-edit-modal/components/geometry-editor.vue
+++ b/src/app/views/river-detail/components/geometry-edit-modal/components/geometry-editor.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script>
-import mapboxgl from "mapbox-gl";
+import maplibregl from "maplibre-gl";
 import { mapState } from "vuex";
 import { mapboxAccessToken } from "@/app/environment";
 import NwiBasemapToggle from "@/app/views/river-index/components/nwi-basemap-toggle.vue";
@@ -255,7 +255,7 @@ export default {
       this.renderDrawFeatures();
     },
     mountMap() {
-      mapboxgl.accessToken = mapboxAccessToken;
+      maplibregl.accessToken = mapboxAccessToken
       const mapProps = {
         container: this.$refs.nhdEditor,
         style: this.baseMapUrl,
@@ -263,7 +263,7 @@ export default {
         fitBoundsOptions: { padding: 80 },
         minZoom: 5,
       };
-      this.map = new mapboxgl.Map(mapProps);
+      this.map = new maplibregl.Map(mapProps);
 
       this.draw = new MapboxDraw({
         displayControlsDefault: false,

--- a/src/app/views/river-detail/components/geometry-edit-modal/components/geometry-editor.vue
+++ b/src/app/views/river-detail/components/geometry-edit-modal/components/geometry-editor.vue
@@ -262,6 +262,7 @@ export default {
         bounds: this.startingBounds,
         fitBoundsOptions: { padding: 80 },
         minZoom: 5,
+        attributionControl: false
       };
       this.map = new maplibregl.Map(mapProps);
 

--- a/src/app/views/river-detail/components/geometry-edit-modal/utils/NHDTilesService.js
+++ b/src/app/views/river-detail/components/geometry-edit-modal/utils/NHDTilesService.js
@@ -7,7 +7,7 @@ import pointToLineDistance from '@turf/point-to-line-distance'
 import { lineString } from '@turf/helpers'
 import Graph from 'graph-data-structure'
 
-// this is a class so it can be initialized with the mapboxgljs map object
+// this is a class so it can be initialized with the maplibregljs map object
 // then continue to use it to populate and refresh the graph and lines caches
 class NHDTilesService {
   constructor(map) {

--- a/src/app/views/river-detail/components/main-tab/components/rapids-section/__tests__/rapid-item.spec.js
+++ b/src/app/views/river-detail/components/main-tab/components/rapids-section/__tests__/rapid-item.spec.js
@@ -4,7 +4,7 @@ import RapidItem from '../components/rapid-item'
 
 const rapid = { approximate: true, character: ['hazard', 'playspot'], description: '<p>\r\n\tLook for the Red Wall and then stay off it</p>\r\n', difficulty: 'IV', distance: 1.5, id: '102548', name: 'Red Wall', photo: { image: { uri: { big: '/photos/archive/885498.jpg', medium: '/photos/archive/medium/885498.jpg' } } } }
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
   Map: () => ({})
 }))
 

--- a/src/app/views/river-detail/components/main-tab/components/rapids-section/__tests__/rapids-section.spec.js
+++ b/src/app/views/river-detail/components/main-tab/components/rapids-section/__tests__/rapids-section.spec.js
@@ -1,7 +1,7 @@
 import RapidsSection from '../rapids-section.vue'
 import { createWrapper } from '@/utils'
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
   Map: () => ({})
 }))
 

--- a/src/app/views/river-detail/components/main-tab/components/rapids-section/components/rapid-map-editor.vue
+++ b/src/app/views/river-detail/components/main-tab/components/rapids-section/components/rapid-map-editor.vue
@@ -27,9 +27,6 @@
 import maplibregl from 'maplibre-gl'
 import { mapState } from 'vuex'
 import { basemapToggleMixin, mapHelpersMixin } from '@/app/global/mixins'
-import {
-  mapboxAccessToken
-} from '@/app/environment'
 import debounce from 'lodash.debounce'
 
 import { point } from '@turf/helpers'
@@ -123,12 +120,12 @@ export default {
       }
     },
     mountMap () {
-      maplibregl.accessToken = mapboxAccessToken
       const mapProps = {
         container: this.$refs.rapidMapEditor,
         style: this.baseMapUrl,
         bounds: this.startingBounds,
-        fitBoundsOptions: { padding: this.boundsPadding }
+        fitBoundsOptions: { padding: this.boundsPadding },
+        attributionControl: false
       }
 
       this.map = new maplibregl.Map(mapProps)
@@ -194,14 +191,12 @@ export default {
     }
   },
   mounted () {
-    if (mapboxAccessToken) {
-      this.mountMap()
+    this.mountMap()
 
-      this.debouncedEmitPOILocation = debounce(this.emitPOILocation, 200, {
-        leading: false,
-        trailing: true
-      })
-    }
+    this.debouncedEmitPOILocation = debounce(this.emitPOILocation, 200, {
+      leading: false,
+      trailing: true
+    })
   },
   beforeDestroy() {
     if(this.map) {

--- a/src/app/views/river-detail/components/main-tab/components/rapids-section/components/rapid-map-editor.vue
+++ b/src/app/views/river-detail/components/main-tab/components/rapids-section/components/rapid-map-editor.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script>
-import mapboxgl from 'mapbox-gl'
+import maplibregl from 'maplibre-gl'
 import { mapState } from 'vuex'
 import { basemapToggleMixin, mapHelpersMixin } from '@/app/global/mixins'
 import {
@@ -123,7 +123,7 @@ export default {
       }
     },
     mountMap () {
-      mapboxgl.accessToken = mapboxAccessToken
+      maplibregl.accessToken = mapboxAccessToken
       const mapProps = {
         container: this.$refs.rapidMapEditor,
         style: this.baseMapUrl,
@@ -131,7 +131,7 @@ export default {
         fitBoundsOptions: { padding: this.boundsPadding }
       }
 
-      this.map = new mapboxgl.Map(mapProps)
+      this.map = new maplibregl.Map(mapProps)
 
       this.map.on('styledata', this.loadReach)
       this.map.on('load', () => {
@@ -151,7 +151,7 @@ export default {
       this.$emit('poiMoved', this.pointOfInterest.getLngLat())
     },
     async renderPOI (geometry) {
-      this.pointOfInterest = new mapboxgl.Marker({
+      this.pointOfInterest = new maplibregl.Marker({
         draggable: true
       }).setLngLat(geometry.coordinates)
         .addTo(this.map)

--- a/src/app/views/river-detail/components/main-tab/components/reports-section/__tests__/reports-section.spec.js
+++ b/src/app/views/river-detail/components/main-tab/components/reports-section/__tests__/reports-section.spec.js
@@ -1,7 +1,7 @@
 import ReportsSection from '../reports-section.vue'
 import { createWrapper } from '@/utils'
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
   Map: () => ({})
 }))
 

--- a/src/app/views/river-detail/components/map-banner.vue
+++ b/src/app/views/river-detail/components/map-banner.vue
@@ -35,9 +35,6 @@ import bbox from '@turf/bbox'
 import { lineString, point, featureCollection } from '@turf/helpers'
 import maplibregl from 'maplibre-gl'
 import NwiMapStyles from '@/app/views/river-index/components/nwi-map-styles'
-import {
-  mapboxAccessToken
-} from '@/app/environment'
 import GeometryEditModal from '@/app/views/river-detail/components/geometry-edit-modal/geometry-edit-modal.vue';
 import { basemapToggleMixin, mapHelpersMixin, objectPermissionsHelpersMixin } from '@/app/global/mixins'
 import { EditBlockOverlay, UtilityBlock } from '@/app/global/components'
@@ -85,13 +82,13 @@ export default {
   },
   methods: {
     mountMap () {
-      maplibregl.accessToken = mapboxAccessToken
       const mapProps = {
         container: this.$refs.nwiMapBanner,
         style: this.baseMapUrlFor("topo"),
         bounds: this.startingBounds,
         fitBoundsOptions: { padding: 80 },
-        interactive: false
+        interactive: false,
+        attributionControl: false
       }
 
       this.map = new maplibregl.Map(mapProps)
@@ -168,7 +165,7 @@ export default {
     }
   },
   mounted () {
-    if (mapboxAccessToken && this.reachGeom) {
+    if (this.reachGeom) {
       this.mountMap()
     }
   },

--- a/src/app/views/river-detail/components/map-banner.vue
+++ b/src/app/views/river-detail/components/map-banner.vue
@@ -33,7 +33,7 @@
 <script>
 import bbox from '@turf/bbox'
 import { lineString, point, featureCollection } from '@turf/helpers'
-import mapboxgl from 'mapbox-gl'
+import maplibregl from 'maplibre-gl'
 import NwiMapStyles from '@/app/views/river-index/components/nwi-map-styles'
 import {
   mapboxAccessToken
@@ -85,7 +85,7 @@ export default {
   },
   methods: {
     mountMap () {
-      mapboxgl.accessToken = mapboxAccessToken
+      maplibregl.accessToken = mapboxAccessToken
       const mapProps = {
         container: this.$refs.nwiMapBanner,
         style: this.baseMapUrlFor("topo"),
@@ -94,7 +94,7 @@ export default {
         interactive: false
       }
 
-      this.map = new mapboxgl.Map(mapProps)
+      this.map = new maplibregl.Map(mapProps)
       this.map.on('styledata', this.loadReach)
     },
     loadReach () {

--- a/src/app/views/river-detail/components/map-tab/components/info-panel/__tests__/info-panel.spec.js
+++ b/src/app/views/river-detail/components/map-tab/components/info-panel/__tests__/info-panel.spec.js
@@ -1,7 +1,7 @@
 import { createWrapper } from '@/utils'
 import InfoPanel from '../info-panel.vue'
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
   Map: () => ({})
 }))
 

--- a/src/app/views/river-detail/components/map-tab/components/rapid-detail/__tests__/rapid-detail.spec.js
+++ b/src/app/views/river-detail/components/map-tab/components/rapid-detail/__tests__/rapid-detail.spec.js
@@ -1,7 +1,7 @@
 import { createWrapper } from '@/utils'
 import RapidDetail from '../rapid-detail.vue'
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
   Map: () => ({})
 }))
 

--- a/src/app/views/river-index/__tests__/nwi-map-search.spec.js
+++ b/src/app/views/river-index/__tests__/nwi-map-search.spec.js
@@ -2,7 +2,7 @@ import { createWrapper } from '@/utils'
 import NwiMapSearch from '@/app/views/river-index/components/nwi-map-search.vue'
 import { SearchBar } from '@/app/global/components'
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
   Map: () => ({})
 }))
 

--- a/src/app/views/river-index/components/nwi-map-styles.js
+++ b/src/app/views/river-index/components/nwi-map-styles.js
@@ -6,7 +6,7 @@ export default {
         minzoom: 11,
         layout: {
           'text-field': ['concat', 'AW Project: ', ['get', 'name']],
-          'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Regular'],
+          'text-font': ['Arial Unicode MS Regular'],
           'text-size': ['interpolate', ['linear'], ['zoom'], 13, 15, 18, 20],
           'text-line-height': 1,
           'text-max-width': 17.5,
@@ -75,7 +75,7 @@ export default {
         minzoom: 11,
         layout: {
           'text-field': ['concat', ['get', 'river'], ':\n', ['get', 'section']],
-          'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Regular'],
+          'text-font': ['Arial Unicode MS Regular'],
           'text-size': ['interpolate', ['linear'], ['zoom'], 13, 15, 18, 20],
           'text-line-height': 1,
           'text-max-width': 17.5,
@@ -99,29 +99,31 @@ export default {
         minzoom: 8,
         layout: {
           'text-field': ['to-string', ['get', 'class']],
-          'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Regular'],
+          'text-font': ['Arial Unicode MS Regular'],
           'text-size': 10,
           'icon-ignore-placement': true,
           'icon-image': [
             'match',
             ['length', ['get', 'class']],
             1,
-            'default-2',
+            'Road/Rectangle white black/2',
             2,
-            'default-2',
+            'Road/Rectangle white black/2',
             3,
-            'default-3',
+            'Road/Rectangle white black/3',
             4,
-            'default-4',
+            'Road/Rectangle white black/4',
             5,
-            'default-4',
+            'Road/Rectangle white black/5',
             6,
-            'default-5',
+            'Road/Rectangle white black/6',
             7,
-            'default-5',
-            8,
-            'default-5',
-            'default-6'
+            'Road/Rectangle white black/7',
+            'Road/Rectangle white black/7'
+          ],
+          'icon-size': ['case',
+            ['>=', ['length', ['get', 'class']], 8], 1.1,
+            1
           ],
           'icon-rotation-alignment': 'viewport',
           'text-offset': [0, -0.5],
@@ -141,7 +143,7 @@ export default {
             ['>', ['length', ['get', 'altname']], 0], ['concat', ' (', ['get', 'altname'], ')'],
             ''
           ]],
-          'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Regular'],
+          'text-font': ['Arial Unicode MS Regular'],
           'text-size': ['interpolate', ['linear'], ['zoom'], 13, 15, 18, 20],
           'text-line-height': 1,
           'text-max-width': 17.5,
@@ -172,7 +174,7 @@ export default {
             ['concat', ['get', 'name'], ' (', ['get', 'difficulty'], ')'],
             ['get', 'name']
           ],
-          'text-font': ['DIN Offc Pro Regular', 'Arial Unicode MS Regular'],
+          'text-font': ['Arial Unicode MS Regular'],
           'text-size': 14,
           'icon-image': [
             'case',

--- a/src/app/views/river-index/components/nwi-map.vue
+++ b/src/app/views/river-index/components/nwi-map.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script>
-import mapboxgl from 'mapbox-gl'
+import maplibregl from 'maplibre-gl'
 import bbox from '@turf/bbox'
 import debounce from 'lodash.debounce'
 import {
@@ -427,7 +427,7 @@ export default {
       })
     },
     mountMap () {
-      mapboxgl.accessToken = this.mapboxAccessToken
+      maplibregl.accessToken = this.mapboxAccessToken
       const mapProps = {
         container: this.$refs.mapContainer,
         style: this.baseMapUrl,
@@ -444,7 +444,7 @@ export default {
         mapProps.center = this.center
         mapProps.zoom = this.startingZoom
       }
-      this.map = new mapboxgl.Map({
+      this.map = new maplibregl.Map({
         ...mapProps,
         transformRequest: (url, resourceType) => {
           // requests for tiles need to match session csrf token.
@@ -459,7 +459,7 @@ export default {
       })
 
       this.map.addControl(
-          new mapboxgl.NavigationControl({ showCompass: true }),
+          new maplibregl.NavigationControl({ showCompass: true }),
           'bottom-left'
       )
 

--- a/src/app/views/river-index/components/nwi-map.vue
+++ b/src/app/views/river-index/components/nwi-map.vue
@@ -3,30 +3,22 @@
     id="nwi-map-container"
     :style="`height:${containerHeight};`"
   >
-    <template v-if="mapboxAccessToken">
-      <div
-        ref="mapContainer"
-        class="nwi-map"
-      />
-      <nwi-map-legend
-        v-if="includeLegend"
-        :color-by="colorBy"
-      />
-      <nwi-map-controls
-        :map-controls="mapControls"
-        :fullscreen-target="fullscreenTarget"
-      />
-      <nwi-result-counter
-        v-if="!hideResultCounter"
-        :loading="mapDataLoading"
-      />
-    </template>
-    <template v-else>
-      <utility-block
-        state="error"
-        text="insert one token to continue"
-      />
-    </template>
+    <div
+      ref="mapContainer"
+      class="nwi-map"
+    />
+    <nwi-map-legend
+      v-if="includeLegend"
+      :color-by="colorBy"
+    />
+    <nwi-map-controls
+      :map-controls="mapControls"
+      :fullscreen-target="fullscreenTarget"
+    />
+    <nwi-result-counter
+      v-if="!hideResultCounter"
+      :loading="mapDataLoading"
+    />
   </div>
 </template>
 
@@ -42,10 +34,8 @@ import {
 } from '.'
 import { basemapToggleMixin } from '@/app/global/mixins'
 import { mapState } from 'vuex'
-import UtilityBlock from '@/app/global/components/utility-block/utility-block.vue'
 import {
   laravelDeploy,
-  mapboxAccessToken,
   nwiTileServer
 } from '@/app/environment'
 
@@ -58,7 +48,6 @@ export default {
   name: 'nwi-map',
   components: {
     NwiMapLegend,
-    UtilityBlock,
     NwiMapControls,
     NwiResultCounter
   },
@@ -126,7 +115,6 @@ export default {
   data () {
     return {
       mapDataLoading: false,
-      mapboxAccessToken: mapboxAccessToken,
       map: null
     }
   },
@@ -207,22 +195,6 @@ export default {
     }
   },
   methods: {
-    // can be used to make tweaks to the mapbox base styles after loading
-    modifyMapboxBaseStyle () {
-      if (this.map.getLayer('satellite')) {
-        this.map.setPaintProperty('satellite', 'raster-opacity', [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          0,
-          0.5,
-          11,
-          0.5,
-          12,
-          1
-        ])
-      }
-    },
     attachMouseEvents (layer) {
       this.map.on('mouseenter', layer, this.mouseenterFeature)
       this.map.on('mouseleave', layer, this.mouseleaveFeature)
@@ -427,13 +399,13 @@ export default {
       })
     },
     mountMap () {
-      maplibregl.accessToken = this.mapboxAccessToken
       const mapProps = {
         container: this.$refs.mapContainer,
         style: this.baseMapUrl,
         trackUserLocation: false,
         touchPitch: false,
-        dragRotate: false
+        dragRotate: false,
+        attributionControl: false
       }
       if (this.startingBounds) {
         mapProps.bounds = this.startingBounds
@@ -464,7 +436,6 @@ export default {
       )
 
       this.map.on('styledata', this.loadAWMapData)
-      this.map.on('styledata', this.modifyMapboxBaseStyle)
 
       // this is a kind of weird solution to the fact that once in a blue moon,
       // our app CSS doesn't finish loading before the map is mounted, which causes
@@ -509,14 +480,10 @@ export default {
     }
   },
   mounted () {
-    if (this.mapboxAccessToken) {
-      this.mountMap()
-    }
+    this.mountMap()
   },
   created () {
-    if (this.mapboxAccessToken) {
-      this.initMap()
-    }
+    this.initMap()
   },
   beforeDestroy() {
     if(this.map) {

--- a/src/app/views/user/components/account/__tests__/user-bookmarks.spec.js
+++ b/src/app/views/user/components/account/__tests__/user-bookmarks.spec.js
@@ -1,7 +1,7 @@
 // import UserBookmarks from '../user-bookmarks.vue'
 // import { createWrapper } from '@/utils'
 
-// jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+// jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
 //   Map: () => ({})
 // }))
 


### PR DESCRIPTION
[Migrate Away from Mapbox for Cost Savings#2715](https://github.com/AmericanWhitewater/wh2o/issues/2715)

- migrates to maplibre gl open source library (v. 1.15 to maintain drop-in compatibility)
- introduces new ESRI api key env var
- switches to ESRI base layers for all maps *except* reach creator

Note: we may be able to transition the reach creator by using ArcGIS Hub's [NHD feature layer](https://hub.arcgis.com/maps/fedmaps::national-hydrography-dataset/about). I don't have a complete grasp on how this works, but if it works the way I think it does, it's likely to actually significantly improve our reach creator mapping interface as well as allowing us to stop using Mapbox altogether. (Update: I just found out It's also possible we could do this directly from a USGS hosted service!!! -- https://apps.nationalmap.gov/services/ lots of interesting options here https://www.usgs.gov/national-hydrography/access-national-hydrography-products)