### PR TITLE
allow env var configuration of basemaps (within ESRI ecosystem)

### DIFF
--- a/src/app/environment/index.js
+++ b/src/app/environment/index.js
@@ -14,6 +14,8 @@ const {
   VUE_APP_WP_API_URL,
   VUE_APP_NWI_TILE_SERVER,
   VUE_APP_MAPBOX_ACCESS_TOKEN,
+  VUE_APP_SATELLITE_MAP_LAYER_ID,
+  VUE_APP_TOPO_MAP_LAYER_ID,
   VUE_APP_BASE_URL,
   VUE_APP_CLIENT_ID,
   VUE_APP_CLIENT_SECRET,
@@ -25,6 +27,8 @@ const {
 
 const environment = NODE_ENV.toLowerCase()
 const arcgisApiKey = VUE_APP_ARCGIS_API_KEY
+const satelliteMapLayerId = VUE_APP_SATELLITE_MAP_LAYER_ID
+const topoMapLayerId = VUE_APP_TOPO_MAP_LAYER_ID
 const apiBaseUrl = VUE_APP_API_BASE_URL
 const appBaseUrl = VUE_APP_BASE_URL
 const assetBaseUrl = STATIC_ASSET_URL || VUE_APP_API_BASE_URL
@@ -48,5 +52,7 @@ export {
   clientId,
   clientSecret,
   laravelDeploy,
-  baseUrl
+  baseUrl,
+  satelliteMapLayerId,
+  topoMapLayerId
 }

--- a/src/app/global/mixins/basemap-toggle.js
+++ b/src/app/global/mixins/basemap-toggle.js
@@ -1,5 +1,5 @@
 import NwiBasemapToggle from "@/app/views/river-index/components/nwi-basemap-toggle.vue";
-import { arcgisApiKey } from "@/app/environment";
+import { arcgisApiKey, satelliteMapLayerId, topoMapLayerId } from "@/app/environment";
 
 export const basemapToggleMixin = {
   computed: {
@@ -20,9 +20,9 @@ export const basemapToggleMixin = {
     baseMapUrlFor(mapType) {
       let basemapStyle;
       if (mapType === "satellite") {
-        basemapStyle = "ArcGIS:Imagery"
+        basemapStyle = satelliteMapLayerId || "ArcGIS:Imagery"
       } else { // mapType == "topo"
-        basemapStyle = "ArcGIS:Topographic"
+        basemapStyle = topoMapLayerId || "ArcGIS:Topographic"
       }
       return `https://basemaps-api.arcgis.com/arcgis/rest/services/styles/${basemapStyle}?type=style&token=${arcgisApiKey}`;
     }


### PR DESCRIPTION
allows quicker configuration of ESRI basemaps via env var for [Migrate Away from Mapbox for Cost Savings#2715](https://github.com/AmericanWhitewater/wh2o/issues/2715)