### PR TITLE
Bug/fix deploy script branch choice

### DIFF
--- a/server_conf/jenkins/deploy.sh
+++ b/server_conf/jenkins/deploy.sh
@@ -1,4 +1,5 @@
 branch=${1:-main}
+git checkout $branch
 git pull origin $branch
 npm install
 export NODE_OPTIONS=--max_old_space_size=4096 

--- a/server_conf/jenkins/deploy.sh
+++ b/server_conf/jenkins/deploy.sh
@@ -1,4 +1,5 @@
-git pull origin development
+branch=${1:-main}
+git pull origin $branch
 npm install
 export NODE_OPTIONS=--max_old_space_size=4096 
 npm run build


### PR DESCRIPTION
addresses [ensure Vue deploy script checks out target branch#539](https://github.com/AmericanWhitewater/wh2o-vue/issues/539)

this is embarrassing but it appears as though we've been deploying `development` to prod since I implemented this script. I've adjusted it to take a command line argument defining the branch to deploy. It defaults to `main`, so on beta I'll need to change the jenkins job.