### PR TITLE
[Tileserver] Pass tileserver token to tileserver request

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 VUE_APP_BASE_URL=/
-VUE_APP_API_BASE_URL=http://localhost:8080/
-VUE_APP_LINK_BASE_URL=https://test.americanwhitewater.org
+VUE_APP_API_BASE_URL=https://www.americanwhitewater.org/
+VUE_APP_ARCGIS_API_KEY=
 VUE_APP_MAPBOX_ACCESS_TOKEN=
-VUE_APP_NWI_TILE_SERVER=http://localhost:8080/tiles/{z}/{x}/{y}.mvt/
+VUE_APP_NWI_TILE_SERVER=https://tileserver.americanwhitewater.local/tiles/{z}/{x}/{y}.mvt/
+VUE_APP_GRAPHQL_HTTP=https://www.americanwhitewater.org/graphql/
 
 VUE_APP_APOLLO_DEV_HELPER=
 VUE_APP_CLIENT_ID=

--- a/src/app/environment/index.js
+++ b/src/app/environment/index.js
@@ -22,7 +22,8 @@ const {
   VUE_APP_API_BASE_URL,
   STATIC_ASSET_URL,
   NODE_ENV = '',
-  VUE_APP_LINK_BASE_URL
+  VUE_APP_LINK_BASE_URL,
+  VUE_APP_NWI_TILE_SERVER_TOKEN_ENDPOINT,
 } = process.env
 
 const environment = NODE_ENV.toLowerCase()
@@ -38,6 +39,7 @@ const mapboxAccessToken = VUE_APP_MAPBOX_ACCESS_TOKEN
 const nwiTileServer = VUE_APP_NWI_TILE_SERVER
 const cmsBaseUrl = VUE_APP_WP_API_URL
 const laravelDeploy = Boolean(VUE_APP_LARAVEL_DEPLOY)
+const nwiTileServerTokenEndpoint = VUE_APP_NWI_TILE_SERVER_TOKEN_ENDPOINT;
 const baseUrl = VUE_APP_LINK_BASE_URL
 
 export {
@@ -54,5 +56,6 @@ export {
   laravelDeploy,
   baseUrl,
   satelliteMapLayerId,
-  topoMapLayerId
+  topoMapLayerId,
+  nwiTileServerTokenEndpoint,
 }

--- a/src/app/views/river-index/components/nwi-map.vue
+++ b/src/app/views/river-index/components/nwi-map.vue
@@ -437,11 +437,13 @@ export default {
         mapProps.center = this.center
         mapProps.zoom = this.startingZoom
       }
+      console.log('creating map');
       this.map = new maplibregl.Map({
         ...mapProps,
         transformRequest: (url, resourceType) => {
           // requests for tiles need to match session csrf token.
           if (resourceType === 'Tile' && new URL(nwiTileServer).origin === new URL(url).origin) {
+            console.log('transforming request');
             return ({
               url,
               headers: { 'tileserver-authorization': tileserverToken },
@@ -450,6 +452,7 @@ export default {
           }
         }
       });
+      console.log('finsihd creating map');
 
       this.map.addControl(
           new maplibregl.NavigationControl({ showCompass: true }),


### PR DESCRIPTION
This change fetches a token from the `nwi-tileserver-token-generator`  api and returns it back to the tileserver api as both a server cookie and as a header. I expect we will make 3 changes to the laravel api receiving this:

1. Verify that the token sent in the header and the token in the cookie are the same (https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie)
2. Decrypt it - this should maybe be done using HMAC since it would be significantly faster but I'm not sure what the best way to share the secret would be
3. Set a `Access-Control-Allow-Origin` for these endpoints so that it's harder for others to fetch from there.
    - beta.rivers.americanwhitewater.org
    - rivers.americanwhitewater.org
  
  
I'm not super vue experienced and so I'm not sure if there are better ways to do this. Perhaps a wrapper component? Ideally, I would just block the requests to the tileserver until the token is there instead of blocking the rendering of the entire map. Is there a way to do this?