### PR TITLE
feature: configure matamo to use vue router

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,8 @@ Vue.use(VueMeta);
 Vue.use(VueApollo);
 Vue.use(VueMatomo, {
   host: 'https://americanwhitewater.matomo.cloud/',
-  siteId: 1
+  siteId: window.origin.includes('beta') ? 2 : 1,
+  router: router,
 });
 
 let mountPoint;


### PR DESCRIPTION
I was missing some configuration options that actually track page views using the router. I also don't want to pollute the analytics with beta traffic so I'm splitting those out.