### PR TITLE
fix styling to not break on edit flows page when comments are too long

### DIFF
--- a/src/app/views/river-detail/components/edit-flows/components/correlation-details.vue
+++ b/src/app/views/river-detail/components/edit-flows/components/correlation-details.vue
@@ -477,7 +477,6 @@ export default {
       }
 
       .range-fields {
-        float: right;
         display: flex;
         flex-direction: column;
         justify-content: space-evenly;
@@ -496,7 +495,6 @@ export default {
           .bx--label {
             text-align: left;
             margin: 0 0.5rem 0 0;
-            white-space: nowrap;
           }
         }
 


### PR DESCRIPTION
addresses [Bug with display of edit flows interface for reach 2750](https://github.com/AmericanWhitewater/wh2o-vue/issues/618)
