### PR TITLE
adjust rapid edit interface to only use 8 digit precision for lat/lng

### DIFF
--- a/src/app/views/river-detail/components/main-tab/components/rapids-section/components/rapid-edit-modal.vue
+++ b/src/app/views/river-detail/components/main-tab/components/rapids-section/components/rapid-edit-modal.vue
@@ -249,7 +249,7 @@ export default {
       });
     },
     updateFormDataGeom(newCoords) {
-      this.formData.geom.coordinates = [newCoords.lng, newCoords.lat];
+      this.formData.geom.coordinates = [newCoords.lng.toFixed(8), newCoords.lat.toFixed(8)];
       this.updateDistance();
     },
     updateDistance() {


### PR DESCRIPTION
limits lat/lng fields in the rapid edit interface to only 8 digits of precision to match the new changes in https://github.com/AmericanWhitewater/wh2o/pull/2836. The rest of the digits were being rounded away anyway in the status quo. 