### PR TITLE
update page titles for various sub-pages to line up with new meta tag…

### DIFF
--- a/src/app/app.vue
+++ b/src/app/app.vue
@@ -34,7 +34,7 @@ export default {
     },
   },
   metaInfo: {
-    title: "American Whitewater",
+    title: "National Whitewater Inventory | American Whitewater",
   },
   created() {
     this.$store.dispatch("User/getProperty");

--- a/src/app/views/river-detail/components/gallery-tab/image-gallery/image-detail.vue
+++ b/src/app/views/river-detail/components/gallery-tab/image-gallery/image-detail.vue
@@ -159,6 +159,16 @@ import AssignToReportModal from "./assign-to-report-modal";
 
 export default {
   name: "image-detail",
+  metaInfo() {
+    if (!this.image) return {};
+    const fullCaption = this.image.caption || 'Untitled';
+    const caption = fullCaption.length > 40 ? fullCaption.substring(0, 37) + '...' : fullCaption;
+    const date = this.imageDate(this.image);
+    const location = this.reachLocation;
+    return {
+      title: `${caption} - ${date} - ${location} | American Whitewater`
+    };
+  },
   components: {
     AwLogo,
     ConfirmDeleteModal,

--- a/src/app/views/river-detail/components/reports-tab/components/report-detail.vue
+++ b/src/app/views/river-detail/components/reports-tab/components/report-detail.vue
@@ -78,6 +78,13 @@ export default {
     report: null,
     loading: true,
   }),
+  metaInfo() {
+    if (!this.report) return { title: 'American Whitewater' };
+    const formattedDate = moment(this.report.post_date).format('MMM D, YYYY');
+    return {
+      title: `${this.report.title} - ${formattedDate} | American Whitewater`
+    }
+  },
   computed: {
     ...mapState({
       user: (state) => state.User.data,

--- a/src/app/views/river-detail/river-detail.vue
+++ b/src/app/views/river-detail/river-detail.vue
@@ -257,6 +257,11 @@ export default {
     accidents: "Accidents",
     credits: "Contributors",
   },
+  metaInfo() {
+    return {
+      title: this.reachDetail?.stub ? `${this.reachDetail.stub.river} - ${this.reachDetail.stub.section} | American Whitewater` : 'American Whitewater'
+    }
+  },
   computed: {
     ...mapState({
       reach: (state) => state.RiverDetail.data,


### PR DESCRIPTION
this is related to https://github.com/AmericanWhitewater/aw-components/pull/1082, because it turns out the vue app was overwriting page title with "American Whitewater" across the board after rendering.